### PR TITLE
Separating API for controlling each channel

### DIFF
--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -121,6 +121,8 @@ class MotorGoMini
   // Either velocity or torque will be used depending on the control mode
   // Store both to avoid erroneous behaviors due to switching units
   // when switching between control modes
+  ControlMode control_mode_ch0;
+  ControlMode control_mode_ch1;
   // Rad/s
   float target_velocity_ch0;
   float target_velocity_ch1;
@@ -170,8 +172,7 @@ class MotorGoMini
   // Set correct targets
   void set_target_helper_ch0();
   void set_target_helper_ch1();
-}
-
+};
 }  // namespace MotorGo
 
 #endif  // MOTORGO_MINI_H

--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -68,6 +68,10 @@ class MotorGoMini
   void set_target_torque_ch0(float target);
   void set_target_torque_ch1(float target);
 
+  // Set target position
+  void set_target_position_ch0(float target);
+  void set_target_position_ch1(float target);
+
   // Get states
   float get_ch0_position();
   float get_ch0_velocity();

--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -53,7 +53,6 @@ class MotorGoMini
   // Enable and disable motors
   void enable_ch0();
   void enable_ch1();
-
   void disable_ch0();
   void disable_ch1();
 
@@ -114,6 +113,23 @@ class MotorGoMini
   const float k_velocity_limit = 100.0;
   const float k_voltage_calibration = 2.0;
 
+  // Current targets
+  // Either velocity or torque will be used depending on the control mode
+  // Store both to avoid erroneous behaviors due to switching units
+  // when switching between control modes
+  // Rad/s
+  float target_velocity_ch0;
+  float target_velocity_ch1;
+  // N*m
+  float target_torque_ch0;
+  float target_torque_ch1;
+  // Rad
+  float target_position_ch0;
+  float target_position_ch1;
+  // V
+  float target_voltage_ch0;
+  float target_voltage_ch1;
+
   // Calibration parameters
   // If should_calibrate is set to true, the motor will be calibrated on startup
   // Else, the calibration will be loaded from EEPROM. If no calibration is
@@ -146,7 +162,11 @@ class MotorGoMini
   // set_control_mode_helper sets parameters for each control_mode option
   // Sets values for torque controller type and motion controller type
   void set_control_mode_helper(BLDCMotor& motor, ControlMode control_mode);
-};
+
+  // Set correct targets
+  void set_target_helper_ch0();
+  void set_target_helper_ch1();
+}
 
 }  // namespace MotorGo
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ void loop()
 
   //   Spin forward
   //   Enable
-  motorgo_mini->set_target_ch0(10.0, 10.0);
+  motorgo_mini->set_target_velocity_ch0(10.0);
   i++;
 
   // Delay necessary amount micros

--- a/src/motorgo_mini.cpp
+++ b/src/motorgo_mini.cpp
@@ -172,20 +172,7 @@ void MotorGo::MotorGoMini::loop_ch0()
   //   Serial.println(analogRead(k_ch0_current_w));
 }
 
-void MotorGo::MotorGoMini::enable_ch0()
-{
-  MotorGo::motor_ch0.enable();
-  //   MotorGo::motor_ch1.enable();
-}
-
-void MotorGo::MotorGoMini::disable_ch0()
-{
-  MotorGo::motor_ch0.disable();
-  //   MotorGo::motor_ch1.disable();
-}
-
-// Setters
-
+////// Helper Functions
 void set_control_mode_helper(BLDCMotor& motor,
                              MotorGo::ControlMode control_mode)
 {
@@ -250,28 +237,84 @@ void MotorGo::MotorGoMini::set_target_helper_ch0()
 
 void MotorGo::MotorGoMini::set_target_helper_ch1()
 {
-  // Switch command based on current control mode
-  switch (control_mode_ch1)
+  if (!enable_foc_studio)
   {
-    case MotorGo::ControlMode::Voltage:
-      motor_ch1.move(target_voltage_ch1);
-      break;
-    case MotorGo::ControlMode::Torque:
-      motor_ch1.move(target_torque_ch1);
-      break;
-    case MotorGo::ControlMode::Velocity:
-      motor_ch1.move(target_velocity_ch1);
-      break;
-    case MotorGo::ControlMode::Position:
-      motor_ch1.move(target_position_ch1);
-      break;
-    case MotorGo::ControlMode::VelocityOpenLoop:
-      motor_ch1.move(target_velocity_ch1);
-      break;
-    case MotorGo::ControlMode::PositionOpenLoop:
-      motor_ch1.move(target_position_ch1);
-      break;
+    // Switch command based on current control mode
+    switch (control_mode_ch1)
+    {
+      case MotorGo::ControlMode::Voltage:
+        motor_ch1.move(target_voltage_ch1);
+        break;
+      case MotorGo::ControlMode::Torque:
+        motor_ch1.move(target_torque_ch1);
+        break;
+      case MotorGo::ControlMode::Velocity:
+        motor_ch1.move(target_velocity_ch1);
+        break;
+      case MotorGo::ControlMode::Position:
+        motor_ch1.move(target_position_ch1);
+        break;
+      case MotorGo::ControlMode::VelocityOpenLoop:
+        motor_ch1.move(target_velocity_ch1);
+        break;
+      case MotorGo::ControlMode::PositionOpenLoop:
+        motor_ch1.move(target_position_ch1);
+        break;
+    }
   }
+}
+
+// Setters
+void MotorGo::MotorGoMini::enable_ch0() { MotorGo::motor_ch0.enable(); }
+void MotorGo::MotorGoMini::enable_ch1() { MotorGo::motor_ch1.enable(); }
+void MotorGo::MotorGoMini::disable_ch0() { MotorGo::motor_ch0.disable(); }
+void MotorGo::MotorGoMini::disable_ch1() { MotorGo::motor_ch1.disable(); }
+
+void MotorGo::MotorGoMini::set_control_mode_ch0(
+    MotorGo::ControlMode control_mode)
+{
+  MotorGo::MotorGoMini::control_mode_ch0 = control_mode;
+  set_control_mode_helper(MotorGo::motor_ch0, control_mode);
+}
+
+void MotorGo::MotorGoMini::set_control_mode_ch1(
+    MotorGo::ControlMode control_mode)
+{
+  MotorGo::MotorGoMini::control_mode_ch1 = control_mode;
+  set_control_mode_helper(MotorGo::motor_ch1, control_mode);
+}
+
+void MotorGo::MotorGoMini::set_target_velocity_ch0(float target)
+{
+  target_velocity_ch0 = target;
+  set_target_helper_ch0();
+}
+void MotorGo::MotorGoMini::set_target_velocity_ch1(float target)
+{
+  target_velocity_ch1 = target;
+  set_target_helper_ch1();
+}
+
+void MotorGo::MotorGoMini::set_target_torque_ch0(float target)
+{
+  target_torque_ch0 = target;
+  set_target_helper_ch0();
+}
+void MotorGo::MotorGoMini::set_target_torque_ch1(float target)
+{
+  target_torque_ch1 = target;
+  set_target_helper_ch1();
+}
+
+void MotorGo::MotorGoMini::set_target_position_ch0(float target)
+{
+  target_position_ch0 = target;
+  set_target_helper_ch0();
+}
+void MotorGo::MotorGoMini::set_target_position_ch1(float target)
+{
+  target_position_ch1 = target;
+  set_target_helper_ch1();
 }
 
 // Getters
@@ -288,13 +331,15 @@ float MotorGo::MotorGoMini::get_ch0_voltage()
   return MotorGo::motor_ch0.voltage.q;
 }
 
-// float MotorGo::MotorGoMini::get_ch1_position()
-// {
-//   return MotorGo::motor_ch1.shaftAngle();
-// }
-// float MotorGo::MotorGoMini::get_ch1_velocity()
-// {
-//   return MotorGo::motor_ch1.shaftVelocity();
-// }
-// float MotorGo::MotorGoMini::get_ch1_voltage() { return
-// MotorGo::motor_ch1.voltage.q; }
+float MotorGo::MotorGoMini::get_ch1_position()
+{
+  return MotorGo::motor_ch1.shaftAngle();
+}
+float MotorGo::MotorGoMini::get_ch1_velocity()
+{
+  return MotorGo::motor_ch1.shaftVelocity();
+}
+float MotorGo::MotorGoMini::get_ch1_voltage()
+{
+  return MotorGo::motor_ch1.voltage.q;
+}

--- a/src/motorgo_mini.cpp
+++ b/src/motorgo_mini.cpp
@@ -222,21 +222,27 @@ void set_control_mode_helper(BLDCMotor& motor,
   }
 }
 
-void MotorGo::MotorGoMini::set_control_mode_ch0(
-    MotorGo::ControlMode control_mode)
+void MotorGo::MotorGoMini::set_target_helper_ch0()
 {
+  // Switch command based on current control mode
+  switch (control_mode_ch0)
+  {
     case MotorGo::ControlMode::Voltage:
       motor_ch0.move(target_voltage_ch0);
-      break;
-    case MotorGo::ControlMode::Velocity ||
-        MotorGo::ControlMode::VelocityOpenLoop:
-      motor_ch0.move(target_velocity_ch0);
       break;
     case MotorGo::ControlMode::Torque:
       motor_ch0.move(target_torque_ch0);
       break;
-    case MotorGo::ControlMode::Position ||
-        MotorGo::ControlMode::PositionOpenLoop:
+    case MotorGo::ControlMode::Velocity:
+      motor_ch0.move(target_velocity_ch0);
+      break;
+    case MotorGo::ControlMode::Position:
+      motor_ch0.move(target_position_ch0);
+      break;
+    case MotorGo::ControlMode::VelocityOpenLoop:
+      motor_ch0.move(target_velocity_ch0);
+      break;
+    case MotorGo::ControlMode::PositionOpenLoop:
       motor_ch0.move(target_position_ch0);
       break;
   }
@@ -250,15 +256,19 @@ void MotorGo::MotorGoMini::set_target_helper_ch1()
     case MotorGo::ControlMode::Voltage:
       motor_ch1.move(target_voltage_ch1);
       break;
-    case MotorGo::ControlMode::Velocity ||
-        MotorGo::ControlMode::VelocityOpenLoop:
-      motor_ch1.move(target_velocity_ch1);
-      break;
     case MotorGo::ControlMode::Torque:
       motor_ch1.move(target_torque_ch1);
       break;
-    case MotorGo::ControlMode::Position ||
-        MotorGo::ControlMode::PositionOpenLoop:
+    case MotorGo::ControlMode::Velocity:
+      motor_ch1.move(target_velocity_ch1);
+      break;
+    case MotorGo::ControlMode::Position:
+      motor_ch1.move(target_position_ch1);
+      break;
+    case MotorGo::ControlMode::VelocityOpenLoop:
+      motor_ch1.move(target_velocity_ch1);
+      break;
+    case MotorGo::ControlMode::PositionOpenLoop:
       motor_ch1.move(target_position_ch1);
       break;
   }

--- a/src/motorgo_mini.cpp
+++ b/src/motorgo_mini.cpp
@@ -343,3 +343,5 @@ float MotorGo::MotorGoMini::get_ch1_voltage()
 {
   return MotorGo::motor_ch1.voltage.q;
 }
+
+// TODO: Implement get torque

--- a/src/motorgo_mini.cpp
+++ b/src/motorgo_mini.cpp
@@ -225,13 +225,43 @@ void set_control_mode_helper(BLDCMotor& motor,
 void MotorGo::MotorGoMini::set_control_mode_ch0(
     MotorGo::ControlMode control_mode)
 {
-  set_control_mode_helper(MotorGo::motor_ch0, control_mode);
+    case MotorGo::ControlMode::Voltage:
+      motor_ch0.move(target_voltage_ch0);
+      break;
+    case MotorGo::ControlMode::Velocity ||
+        MotorGo::ControlMode::VelocityOpenLoop:
+      motor_ch0.move(target_velocity_ch0);
+      break;
+    case MotorGo::ControlMode::Torque:
+      motor_ch0.move(target_torque_ch0);
+      break;
+    case MotorGo::ControlMode::Position ||
+        MotorGo::ControlMode::PositionOpenLoop:
+      motor_ch0.move(target_position_ch0);
+      break;
+  }
 }
 
-void MotorGo::MotorGoMini::set_control_mode_ch1(
-    MotorGo::ControlMode control_mode)
+void MotorGo::MotorGoMini::set_target_helper_ch1()
 {
-  set_control_mode_helper(MotorGo::motor_ch1, control_mode);
+  // Switch command based on current control mode
+  switch (control_mode_ch1)
+  {
+    case MotorGo::ControlMode::Voltage:
+      motor_ch1.move(target_voltage_ch1);
+      break;
+    case MotorGo::ControlMode::Velocity ||
+        MotorGo::ControlMode::VelocityOpenLoop:
+      motor_ch1.move(target_velocity_ch1);
+      break;
+    case MotorGo::ControlMode::Torque:
+      motor_ch1.move(target_torque_ch1);
+      break;
+    case MotorGo::ControlMode::Position ||
+        MotorGo::ControlMode::PositionOpenLoop:
+      motor_ch1.move(target_position_ch1);
+      break;
+  }
 }
 
 // Getters

--- a/src/motorgo_mini.cpp
+++ b/src/motorgo_mini.cpp
@@ -138,14 +138,6 @@ void MotorGo::MotorGoMini::init_ch0(bool should_calibrate,
   //   MotorGo::motor_ch1.disable();
 }
 
-void MotorGo::MotorGoMini::set_target_velocity_ch0(float target)
-{
-  if (!enable_foc_studio)
-  {
-    MotorGo::motor_ch0.move(target);
-  }
-}
-
 void MotorGo::MotorGoMini::loop_ch0()
 {
   MotorGo::motor_ch0.loopFOC();


### PR DESCRIPTION
Updated API to fully separate each motor controller channel:
* Add `set_target_position_*" functions
* Added separate variables to store targets for each control mode
* Defined all getter and setters for both channels

Closes #8 