### PR TITLE
Update API to take PID parameters and Motor Parameters on init

### DIFF
--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -153,17 +153,17 @@ class MotorGoMini
   ControlMode control_mode_ch0;
   ControlMode control_mode_ch1;
   // Rad/s
-  float target_velocity_ch0;
-  float target_velocity_ch1;
+  float target_velocity_ch0 = 0.0f;
+  float target_velocity_ch1 = 0.0f;
   // N*m
-  float target_torque_ch0;
-  float target_torque_ch1;
+  float target_torque_ch0 = 0.0f;
+  float target_torque_ch1 = 0.0f;
   // Rad
-  float target_position_ch0;
-  float target_position_ch1;
+  float target_position_ch0 = 0.0f;
+  float target_position_ch1 = 0.0f;
   // V
-  float target_voltage_ch0;
-  float target_voltage_ch1;
+  float target_voltage_ch0 = 0.0f;
+  float target_voltage_ch1 = 0.0f;
 
   // Calibration parameters
   // If should_calibrate is set to true, the motor will be calibrated on startup

--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -50,6 +50,15 @@ class MotorGoMini
   void loop_ch0();
   void loop_ch1();
 
+  void set_torque_controller_ch0(PIDParameters params);
+  void set_torque_controller_ch1(PIDParameters params);
+
+  void set_velocity_controller_ch0(PIDParameters params);
+  void set_velocity_controller_ch1(PIDParameters params);
+
+  void set_position_controller_ch0(PIDParameters params);
+  void set_position_controller_ch1(PIDParameters params);
+
   // Enable and disable motors
   void enable_ch0();
   void enable_ch1();
@@ -117,6 +126,17 @@ class MotorGoMini
   const float k_velocity_limit = 100.0;
   const float k_voltage_calibration = 2.0;
 
+  // Store whether the parameters have been set
+  // If not, the motor will not run be disabled when a command is received
+  bool pid_torque_ch0_enabled = false;
+  bool pid_torque_ch1_enabled = false;
+
+  bool pid_velocity_ch0_enabled = false;
+  bool pid_velocity_ch1_enabled = false;
+
+  bool pid_position_ch0_enabled = false;
+  bool pid_position_ch1_enabled = false;
+
   // Current targets
   // Either velocity or torque will be used depending on the control mode
   // Store both to avoid erroneous behaviors due to switching units
@@ -172,6 +192,10 @@ class MotorGoMini
   // Set correct targets
   void set_target_helper_ch0();
   void set_target_helper_ch1();
+
+  void set_torque_controller_helper(BLDCMotor& motor, PIDParameters params);
+  void set_velocity_controller_helper(BLDCMotor& motor, PIDParameters params);
+  void set_position_controller_helper(BLDCMotor& motor, PIDParameters params);
 };
 }  // namespace MotorGo
 

--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -16,6 +16,7 @@ namespace MotorGo
 // Control config struct
 enum ControlMode
 {
+  None,
   Voltage,
   Velocity,
   Torque,
@@ -150,8 +151,9 @@ class MotorGoMini
   // Either velocity or torque will be used depending on the control mode
   // Store both to avoid erroneous behaviors due to switching units
   // when switching between control modes
-  ControlMode control_mode_ch0;
-  ControlMode control_mode_ch1;
+  // Set to None by default to require user to set a control mode
+  ControlMode control_mode_ch0 = None;
+  ControlMode control_mode_ch1 = None;
   // Rad/s
   float target_velocity_ch0 = 0.0f;
   float target_velocity_ch1 = 0.0f;

--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -24,6 +24,15 @@ enum ControlMode
   PositionOpenLoop
 };
 
+struct PIDParameters
+{
+  float p;
+  float i;
+  float d;
+  float output_ramp;
+  float lpf_time_constant;
+};
+
 // TODO: These are global because the SimpleFOC commander API doesn't support
 // lambdas to save state in for the callback Need to decide if this is the best
 // solution, or if there is something better we can do

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,15 +6,38 @@
 #define LOOP_US 1000000 / LOOP_HZ
 
 MotorGo::MotorGoMini* motorgo_mini;
+MotorGo::MotorParameters motor_params_ch0;
+MotorGo::PIDParameters velocity_pid_params_ch0;
 
 void setup()
 {
   Serial.begin(115200);
+
+  // Setup motor parameters
+  motor_params_ch0.pole_pairs = 11;
+  motor_params_ch0.power_supply_voltage = 9.0;
+  motor_params_ch0.voltage_limit = 9.0;
+  motor_params_ch0.current_limit = 320;
+  motor_params_ch0.velocity_limit = 100.0;
+  motor_params_ch0.calibration_voltage = 2.0;
+
+  // Setup PID parameters
+  velocity_pid_params_ch0.p = 4.0;
+  velocity_pid_params_ch0.i = 0.5;
+  velocity_pid_params_ch0.d = 0.0;
+  velocity_pid_params_ch0.output_ramp = 10000.0;
+  velocity_pid_params_ch0.lpf_time_constant = 0.1;
+
   // Instantiate motorgo mini board
   motorgo_mini = new MotorGo::MotorGoMini();
 
   // Setup Ch0 with FOCStudio enabled
-  motorgo_mini->init_ch0(false, false);
+  motorgo_mini->init_ch0(motor_params_ch0, false, false);
+  // Set velocity controller parameters
+  motorgo_mini->set_velocity_controller_ch0(velocity_pid_params_ch0);
+  // Set closed-loop velocity control mode
+  motorgo_mini->set_control_mode_ch0(MotorGo::ControlMode::Velocity);
+
   motorgo_mini->enable_ch0();
 }
 

--- a/src/motorgo_mini.cpp
+++ b/src/motorgo_mini.cpp
@@ -113,19 +113,6 @@ void MotorGo::MotorGoMini::init_ch0(bool should_calibrate,
   // Initialize motors
   init_helper(MotorGo::motor_ch0, driver_ch0, sensor_calibrated_ch0,
               encoder_ch0, "ch0");
-  //   init_helper(MotorGo::motor_ch1, driver_ch1, sensor_calibrated_ch1,
-  //   encoder_ch1, "ch1");
-
-  // Set PID parameters for both motors
-  //   MotorGo::motor_ch1.PID_velocity.P = 0.75;
-  //   MotorGo::motor_ch1.PID_velocity.I = 0.09;
-  //   MotorGo::motor_ch1.PID_velocity.D = 0.001;
-  //   MotorGo::motor_ch1.PID_velocity.output_ramp = 10000.0;
-
-  MotorGo::motor_ch0.PID_velocity.P = 0.75;
-  MotorGo::motor_ch0.PID_velocity.I = 0.09;
-  MotorGo::motor_ch0.PID_velocity.D = 0.001;
-  MotorGo::motor_ch0.PID_velocity.output_ramp = 10000.0;
 
   // add command to commander
   if (enable_foc_studio)

--- a/src/motorgo_mini.cpp
+++ b/src/motorgo_mini.cpp
@@ -134,8 +134,8 @@ void MotorGo::MotorGoMini::init_ch0(bool should_calibrate,
     command.add('1', do_target_ch1, (char*)"target");
   }
 
-  MotorGo::motor_ch0.disable();
-  //   MotorGo::motor_ch1.disable();
+  disable_ch0();
+  disable_ch1();
 }
 
 void MotorGo::MotorGoMini::loop_ch0()
@@ -210,12 +210,28 @@ void MotorGo::MotorGoMini::set_target_helper_ch0()
       motor_ch0.move(target_voltage_ch0);
       break;
     case MotorGo::ControlMode::Torque:
+      //  Disable motor if PID params not set
+      if (!pid_torque_ch0_enabled)
+      {
+        disable_ch0();
+      }
       motor_ch0.move(target_torque_ch0);
       break;
     case MotorGo::ControlMode::Velocity:
+      // Disable motor if PID params not set
+      if (!pid_velocity_ch0_enabled)
+      {
+        disable_ch0();
+      }
+
       motor_ch0.move(target_velocity_ch0);
       break;
     case MotorGo::ControlMode::Position:
+      // Disable motor if PID params not set
+      if (!pid_position_ch0_enabled)
+      {
+        disable_ch0();
+      }
       motor_ch0.move(target_position_ch0);
       break;
     case MotorGo::ControlMode::VelocityOpenLoop:
@@ -238,12 +254,27 @@ void MotorGo::MotorGoMini::set_target_helper_ch1()
         motor_ch1.move(target_voltage_ch1);
         break;
       case MotorGo::ControlMode::Torque:
+        //   Disable motor if PID params not set
+        if (!pid_torque_ch1_enabled)
+        {
+          disable_ch1();
+        }
         motor_ch1.move(target_torque_ch1);
         break;
       case MotorGo::ControlMode::Velocity:
+        //  Disable motor if PID params not set
+        if (!pid_velocity_ch1_enabled)
+        {
+          disable_ch1();
+        }
         motor_ch1.move(target_velocity_ch1);
         break;
       case MotorGo::ControlMode::Position:
+        //  Disable motor if PID params not set
+        if (!pid_position_ch1_enabled)
+        {
+          disable_ch1();
+        }
         motor_ch1.move(target_position_ch1);
         break;
       case MotorGo::ControlMode::VelocityOpenLoop:

--- a/src/motorgo_mini.cpp
+++ b/src/motorgo_mini.cpp
@@ -256,7 +256,79 @@ void MotorGo::MotorGoMini::set_target_helper_ch1()
   }
 }
 
+void MotorGo::MotorGoMini::set_torque_controller_helper(
+    BLDCMotor& motor, MotorGo::PIDParameters params)
+{
+  motor.PID_current_q.P = params.p;
+  motor.PID_current_q.I = params.i;
+  motor.PID_current_q.D = params.d;
+  motor.PID_current_q.output_ramp = params.output_ramp;
+  motor.LPF_current_q.Tf = params.lpf_time_constant;
+}
+
+void MotorGo::MotorGoMini::set_velocity_controller_helper(
+    BLDCMotor& motor, MotorGo::PIDParameters params)
+{
+  motor.PID_velocity.P = params.p;
+  motor.PID_velocity.I = params.i;
+  motor.PID_velocity.D = params.d;
+  motor.PID_velocity.output_ramp = params.output_ramp;
+  motor.LPF_velocity.Tf = params.lpf_time_constant;
+}
+
+void MotorGo::MotorGoMini::set_position_controller_helper(
+    BLDCMotor& motor, MotorGo::PIDParameters params)
+{
+  motor.P_angle.P = params.p;
+  motor.P_angle.I = params.i;
+  motor.P_angle.D = params.d;
+  motor.P_angle.output_ramp = params.output_ramp;
+  motor.LPF_angle.Tf = params.lpf_time_constant;
+}
+
 // Setters
+void MotorGo::MotorGoMini::set_torque_controller_ch0(
+    MotorGo::PIDParameters params)
+{
+  set_torque_controller_helper(MotorGo::motor_ch0, params);
+  pid_torque_ch0_enabled = true;
+}
+
+void MotorGo::MotorGoMini::set_torque_controller_ch1(
+    MotorGo::PIDParameters params)
+{
+  set_torque_controller_helper(MotorGo::motor_ch1, params);
+  pid_torque_ch1_enabled = true;
+}
+
+void MotorGo::MotorGoMini::set_velocity_controller_ch0(
+    MotorGo::PIDParameters params)
+{
+  set_velocity_controller_helper(MotorGo::motor_ch0, params);
+  pid_velocity_ch0_enabled = true;
+}
+
+void MotorGo::MotorGoMini::set_velocity_controller_ch1(
+    MotorGo::PIDParameters params)
+{
+  set_velocity_controller_helper(MotorGo::motor_ch1, params);
+  pid_velocity_ch1_enabled = true;
+}
+
+void MotorGo::MotorGoMini::set_position_controller_ch0(
+    MotorGo::PIDParameters params)
+{
+  set_position_controller_helper(MotorGo::motor_ch0, params);
+  pid_position_ch0_enabled = true;
+}
+
+void MotorGo::MotorGoMini::set_position_controller_ch1(
+    MotorGo::PIDParameters params)
+{
+  set_position_controller_helper(MotorGo::motor_ch1, params);
+  pid_position_ch1_enabled = true;
+}
+
 void MotorGo::MotorGoMini::enable_ch0() { MotorGo::motor_ch0.enable(); }
 void MotorGo::MotorGoMini::enable_ch1() { MotorGo::motor_ch1.enable(); }
 void MotorGo::MotorGoMini::disable_ch0() { MotorGo::motor_ch0.disable(); }


### PR DESCRIPTION
* MGM Driver no longer sets default PID parameters or motor parameter
* Motor parameters are now required to be passed on init
* PID parameters are required to be set for torque, velocity, position mode independently
* Control modes will not run without respective PID parameters being set
* Defined PIDParameters and MotorParameters structs
* Updated default control targets to be 0
* Added init and loop for Channel 1

Tested on MotorGo board. Closes #3 