### PR TITLE
Add support for zeroing encoder

### DIFF
--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -30,7 +30,7 @@ struct PIDParameters
   float p;
   float i;
   float d;
-  float output_ramp = 10000f;
+  float output_ramp = 10000.0f;
   float lpf_time_constant = 0.1f;
   float limit = 10000.0f;
 };

--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -103,6 +103,10 @@ class MotorGoMini
   void set_target_position_ch0(float target);
   void set_target_position_ch1(float target);
 
+  // Zero Position
+  void zero_position_ch0();
+  void zero_position_ch1();
+
   // Get states
   float get_ch0_position();
   float get_ch0_velocity();

--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -30,8 +30,9 @@ struct PIDParameters
   float p;
   float i;
   float d;
-  float output_ramp;
-  float lpf_time_constant;
+  float output_ramp = 10000f;
+  float lpf_time_constant = 0.1f;
+  float limit = 10000.0f;
 };
 
 struct MotorParameters
@@ -39,8 +40,8 @@ struct MotorParameters
   int pole_pairs;
   float power_supply_voltage;
   float voltage_limit;
-  float current_limit;
-  float velocity_limit;
+  float current_limit = 1000.0f;
+  float velocity_limit = 1000.0f;
   float calibration_voltage;
 };
 

--- a/library.json
+++ b/library.json
@@ -22,10 +22,9 @@
             "owner": "askuric",
             "name": "Simple FOC",
             "version": "^2.3.0"
-        },
-        {
+        },gi
             "name": "SimpleFOCDrivers",
-            "version": "https://github.com/Roam-Studios/Arduino-FOC-drivers.git"
+            "version": "https://github.com/Roam-Studios/Arduino-FOC-drivers.git#ccw-bug-fix"
         },
         {
             "name": "ESP-Options",

--- a/library.json
+++ b/library.json
@@ -23,6 +23,7 @@
             "name": "Simple FOC",
             "version": "^2.3.0"
         },
+        {
             "name": "SimpleFOCDrivers",
             "version": "https://github.com/Roam-Studios/Arduino-FOC-drivers.git#ccw-bug-fix"
         },

--- a/library.json
+++ b/library.json
@@ -22,7 +22,7 @@
             "owner": "askuric",
             "name": "Simple FOC",
             "version": "^2.3.0"
-        },gi
+        },
             "name": "SimpleFOCDrivers",
             "version": "https://github.com/Roam-Studios/Arduino-FOC-drivers.git#ccw-bug-fix"
         },

--- a/src/motorgo_mini.cpp
+++ b/src/motorgo_mini.cpp
@@ -467,6 +467,16 @@ void MotorGo::MotorGoMini::set_target_position_ch1(float target)
   set_target_helper_ch1();
 }
 
+void MotorGo::MotorGoMini::zero_position_ch0()
+{
+  MotorGo::motor_ch0.sensor_offset = MotorGo::motor_ch0.shaftAngle();
+}
+
+void MotorGo::MotorGoMini::zero_position_ch1()
+{
+  MotorGo::motor_ch1.sensor_offset = MotorGo::motor_ch1.shaftAngle();
+}
+
 // Getters
 float MotorGo::MotorGoMini::get_ch0_position()
 {

--- a/src/motorgo_mini.cpp
+++ b/src/motorgo_mini.cpp
@@ -62,7 +62,6 @@ void MotorGo::MotorGoMini::init_helper(MotorParameters params,
 
   // Set motor control parameters
   motor.foc_modulation = FOCModulationType::SpaceVectorPWM;
-  motor.velocity_limit = params.velocity_limit;
   motor.voltage_limit = params.voltage_limit;
   motor.current_limit = params.current_limit;
 
@@ -349,6 +348,7 @@ void MotorGo::MotorGoMini::set_torque_controller_helper(
   motor.PID_current_q.I = params.i;
   motor.PID_current_q.D = params.d;
   motor.PID_current_q.output_ramp = params.output_ramp;
+  motor.PID_current_q.limit = params.limit;
   motor.LPF_current_q.Tf = params.lpf_time_constant;
 }
 
@@ -359,6 +359,7 @@ void MotorGo::MotorGoMini::set_velocity_controller_helper(
   motor.PID_velocity.I = params.i;
   motor.PID_velocity.D = params.d;
   motor.PID_velocity.output_ramp = params.output_ramp;
+  motor.PID_velocity.limit = params.limit;
   motor.LPF_velocity.Tf = params.lpf_time_constant;
 }
 
@@ -369,6 +370,7 @@ void MotorGo::MotorGoMini::set_position_controller_helper(
   motor.P_angle.I = params.i;
   motor.P_angle.D = params.d;
   motor.P_angle.output_ramp = params.output_ramp;
+  motor.P_angle.limit = params.limit;
   motor.LPF_angle.Tf = params.lpf_time_constant;
 }
 


### PR DESCRIPTION
Exposes zero_position_ch0 and zero_position_ch1 functions in the API. Sets sensor_offset in SimpleFOC. Also removes the velocity limit from motor parameters and adds it to the PID parameters. This standardizes setting torque, velocity, and angle limits.