### PR TITLE
Add example projects

### DIFF
--- a/examples/balance_bot.cpp
+++ b/examples/balance_bot.cpp
@@ -1,0 +1,181 @@
+#include <Adafruit_MPU6050.h>
+#include <Arduino.h>
+
+#include "Wire.h"
+#include "configurable.h"
+#include "motorgo_mini.h"
+#include "readable.h"
+#include "web_server.h"
+
+MotorGo::MotorGoMini* motorgo_mini;
+MotorGo::MotorParameters motor_params_ch0;
+MotorGo::MotorParameters motor_params_ch1;
+
+// instantiate pid motorgo pid params
+MotorGo::PIDParameters current_pid_params_ch0;
+MotorGo::PIDParameters current_pid_params_ch1;
+
+MotorGo::PIDParameters velocity_pid_params_ch0;
+MotorGo::PIDParameters velocity_pid_params_ch1;
+
+MotorGo::PIDParameters position_pid_params_ch0;
+MotorGo::PIDParameters position_pid_params_ch1;
+
+Adafruit_MPU6050 mpu;
+
+// Function to print at a maximum frequency
+void freq_println(String str, int freq)
+{
+  static unsigned long last_print_time = 0;
+  unsigned long now = millis();
+
+  if (now - last_print_time > 1000 / freq)
+  {
+    Serial.println(str);
+    last_print_time = now;
+  }
+}
+
+void setup()
+{
+  Serial.begin(115200);
+
+  //   Configure Wire on pins 8, 38
+  Wire.begin(8, 38);
+
+  //   Begin IMU on Wire
+  if (!mpu.begin(MPU6050_I2CADDR_DEFAULT, &Wire))
+  {
+    Serial.println("Failed to find MPU6050 chip");
+    while (1)
+    {
+      delay(10);
+    }
+  }
+
+  delay(3000);
+
+  // Setup motor parameters
+  motor_params_ch0.pole_pairs = 7;
+  motor_params_ch0.power_supply_voltage = 5.0;
+  motor_params_ch0.voltage_limit = 5.0;
+  motor_params_ch0.current_limit = 300;
+  motor_params_ch0.velocity_limit = 100.0;
+  motor_params_ch0.calibration_voltage = 2.0;
+
+  motor_params_ch1.pole_pairs = 7;
+  motor_params_ch1.power_supply_voltage = 5.0;
+  motor_params_ch1.voltage_limit = 5.0;
+  motor_params_ch1.current_limit = 300;
+  motor_params_ch1.velocity_limit = 100.0;
+  motor_params_ch1.calibration_voltage = 2.0;
+
+  // Instantiate motorgo mini board
+  motorgo_mini = new MotorGo::MotorGoMini();
+
+  // Setup Ch0 with FOCStudio enabled
+  bool calibrate = false;
+  bool enable_foc_studio = false;
+  motorgo_mini->init_ch0(motor_params_ch0, calibrate, enable_foc_studio);
+  motorgo_mini->init_ch1(motor_params_ch1, calibrate, enable_foc_studio);
+
+  // Set velocity controller parameters
+  // Setup PID parameters - velocity
+
+  float vel_p = 0.5;
+  float vel_i = 0.0;
+  float vel_d = 0.0;
+
+  velocity_pid_params_ch0.p = vel_p;
+  velocity_pid_params_ch0.i = vel_i;
+  velocity_pid_params_ch0.d = vel_d;
+  velocity_pid_params_ch0.output_ramp = 10000.0;
+  velocity_pid_params_ch0.lpf_time_constant = 0.11;
+
+  velocity_pid_params_ch1.p = vel_p;
+  velocity_pid_params_ch1.i = vel_i;
+  velocity_pid_params_ch1.d = vel_d;
+  velocity_pid_params_ch1.output_ramp = 10000.0;
+  velocity_pid_params_ch1.lpf_time_constant = 0.11;
+
+  // Setup PID parameters - position
+  // set up p controller only for position control.
+  float pos_p = 5.0;
+  float pos_i = 0.5;
+  float pos_d = 0.0;
+
+  position_pid_params_ch0.p = pos_p;
+  position_pid_params_ch0.i = pos_i;
+  position_pid_params_ch0.d = pos_d;
+  position_pid_params_ch0.output_ramp = 10000.0;
+  position_pid_params_ch0.lpf_time_constant = 0.11;
+
+  position_pid_params_ch1.p = pos_p;
+  position_pid_params_ch1.i = pos_i;
+  position_pid_params_ch1.d = pos_d;
+  position_pid_params_ch1.output_ramp = 10000.0;
+  position_pid_params_ch1.lpf_time_constant = 0.11;
+
+  // Instantiate controllers
+  motorgo_mini->set_velocity_controller_ch0(velocity_pid_params_ch0);
+  motorgo_mini->set_velocity_controller_ch1(velocity_pid_params_ch1);
+
+  motorgo_mini->set_position_controller_ch0(position_pid_params_ch0);
+  motorgo_mini->set_position_controller_ch1(position_pid_params_ch1);
+
+  //   Set closed-loop position mode
+  motorgo_mini->set_control_mode_ch0(MotorGo::ControlMode::Position);
+  motorgo_mini->set_control_mode_ch1(MotorGo::ControlMode::Position);
+
+  //   Print url: http://{IP_ADDRESS}:PORT
+  Serial.print("Please connect to http://");
+  Serial.print(WiFi.localIP());
+  Serial.print(":");
+  Serial.println(8080);
+
+  // enable controllers and prepare for the loop
+  //   motorgo_mini->enable_ch0();
+  //   motorgo_mini->enable_ch1();
+}
+
+void loop()
+{
+  // Print IMU data
+  sensors_event_t a, g, temp;
+  mpu.getEvent(&a, &g, &temp);
+
+  Serial.println("IMU Data:");
+  Serial.print("aX = ");
+  Serial.print(a.acceleration.x);
+  Serial.print(" aY = ");
+  Serial.print(a.acceleration.y);
+  Serial.print(" aZ = ");
+  Serial.print(a.acceleration.z);
+
+  Serial.print(" gX = ");
+  Serial.print(g.gyro.x);
+  Serial.print(" gY = ");
+  Serial.print(g.gyro.y);
+  Serial.print(" gZ = ");
+  Serial.print(g.gyro.z);
+
+  Serial.print(" t = ");
+  Serial.println(temp.temperature);
+
+  delay(100);
+
+  // Run Ch0
+  //   motorgo_mini->loop_ch0();
+  //   motorgo_mini->loop_ch1();
+
+  // measure positions
+  //   float ch0_pos = motorgo_mini->get_ch0_position();
+  //   float ch1_pos = motorgo_mini->get_ch1_position();
+
+  //   // set target positions between each motor
+  //   motorgo_mini->set_target_position_ch0(ch1_pos);
+  //   motorgo_mini->set_target_position_ch1(ch0_pos);
+
+  //   String x = "ch0 pos: " + String(ch0_pos);
+  //   String y = "ch1 pos: " + String(ch1_pos);
+}

--- a/examples/haptics_demo.cpp
+++ b/examples/haptics_demo.cpp
@@ -174,6 +174,8 @@ void position_pid_update_ch0(float value)
   motorgo_mini->reset_position_controller_ch0();
   motorgo_mini->reset_velocity_controller_ch0();
   motorgo_mini->reset_torque_controller_ch0();
+
+  motorgo_mini->enable_ch0();
 }
 
 void position_pid_update_ch1(float value)
@@ -185,6 +187,8 @@ void position_pid_update_ch1(float value)
   motorgo_mini->reset_position_controller_ch1();
   motorgo_mini->reset_velocity_controller_ch1();
   motorgo_mini->reset_torque_controller_ch1();
+
+  motorgo_mini->enable_ch1();
 }
 
 void velocity_pid_update_ch0(float value)
@@ -195,6 +199,8 @@ void velocity_pid_update_ch0(float value)
   //   Reset velocity and torque controllers;
   motorgo_mini->reset_velocity_controller_ch0();
   motorgo_mini->reset_torque_controller_ch0();
+
+  motorgo_mini->enable_ch0();
 }
 
 void velocity_pid_update_ch1(float value)
@@ -205,6 +211,8 @@ void velocity_pid_update_ch1(float value)
   //   Reset velocity and torque controllers;
   motorgo_mini->reset_velocity_controller_ch1();
   motorgo_mini->reset_torque_controller_ch1();
+
+  motorgo_mini->enable_ch1();
 }
 
 void current_pid_update_ch0(float value)
@@ -214,6 +222,8 @@ void current_pid_update_ch0(float value)
 
   //   Reset torque controller;
   motorgo_mini->reset_torque_controller_ch0();
+
+  motorgo_mini->enable_ch0();
 }
 
 void current_pid_update_ch1(float value)
@@ -223,6 +233,8 @@ void current_pid_update_ch1(float value)
 
   //   Reset torque controller;
   motorgo_mini->reset_torque_controller_ch1();
+
+  motorgo_mini->enable_ch1();
 }
 
 // Function to print at a maximum frequency

--- a/examples/haptics_demo.cpp
+++ b/examples/haptics_demo.cpp
@@ -115,6 +115,24 @@ ESPWifiConfig::Configurable<float> position_lpf_ch1(
     position_pid_params_ch1.lpf_time_constant, "/ch1/position/lpf",
     "Low pass filter time constant for Channel 1 position controller");
 
+bool motors_enabled = false;
+ESPWifiConfig::Configurable<bool> enable_motors(motors_enabled, "/enable",
+                                                "Enable motors");
+
+void enable_motors_callback(bool value)
+{
+  if (value)
+  {
+    motorgo_mini->enable_ch0();
+    motorgo_mini->enable_ch1();
+  }
+  else
+  {
+    motorgo_mini->disable_ch0();
+    motorgo_mini->disable_ch1();
+  }
+}
+
 bool save_pid_params_ch0()
 {
   motorgo_mini->save_position_controller_ch0();
@@ -310,6 +328,8 @@ void setup()
   position_d_ch0.set_post_callback(position_pid_update_ch0);
   position_lpf_ch0.set_post_callback(position_pid_update_ch0);
 
+  enable_motors.set_post_callback(enable_motors_callback);
+
   ESPWifiConfig::WebServer::getInstance().start();
 
   // Setup motor parameters
@@ -391,8 +411,8 @@ void setup()
   Serial.println(8080);
 
   // enable controllers and prepare for the loop
-  motorgo_mini->enable_ch0();
-  motorgo_mini->enable_ch1();
+  //   motorgo_mini->enable_ch0();
+  //   motorgo_mini->enable_ch1();
 }
 
 void loop()

--- a/examples/haptics_demo.cpp
+++ b/examples/haptics_demo.cpp
@@ -339,37 +339,37 @@ void setup()
   // Set velocity controller parameters
   // Setup PID parameters - velocity
 
-  float velP = 0.5;
-  float velI = 0.0;
-  float velD = 0.0;
+  float vel_p = 0.5;
+  float vel_i = 0.0;
+  float vel_d = 0.0;
 
-  velocity_pid_params_ch0.p = velP;
-  velocity_pid_params_ch0.i = velI;
-  velocity_pid_params_ch0.d = velD;
+  velocity_pid_params_ch0.p = vel_p;
+  velocity_pid_params_ch0.i = vel_i;
+  velocity_pid_params_ch0.d = vel_d;
   velocity_pid_params_ch0.output_ramp = 10000.0;
   velocity_pid_params_ch0.lpf_time_constant = 0.11;
 
-  velocity_pid_params_ch1.p = velP;
-  velocity_pid_params_ch1.i = velI;
-  velocity_pid_params_ch1.d = velD;
+  velocity_pid_params_ch1.p = vel_p;
+  velocity_pid_params_ch1.i = vel_i;
+  velocity_pid_params_ch1.d = vel_d;
   velocity_pid_params_ch1.output_ramp = 10000.0;
   velocity_pid_params_ch1.lpf_time_constant = 0.11;
 
   // Setup PID parameters - position
   // set up p controller only for position control.
-  float posP = 5.0;
-  float posI = 0.5;
-  float posD = 0.0;
+  float pos_p = 5.0;
+  float pos_i = 0.5;
+  float pos_d = 0.0;
 
-  position_pid_params_ch0.p = posP;
-  position_pid_params_ch0.i = posI;
-  position_pid_params_ch0.d = posD;
+  position_pid_params_ch0.p = pos_p;
+  position_pid_params_ch0.i = pos_i;
+  position_pid_params_ch0.d = pos_d;
   position_pid_params_ch0.output_ramp = 10000.0;
   position_pid_params_ch0.lpf_time_constant = 0.11;
 
-  position_pid_params_ch1.p = posP;
-  position_pid_params_ch1.i = posI;
-  position_pid_params_ch1.d = posD;
+  position_pid_params_ch1.p = pos_p;
+  position_pid_params_ch1.i = pos_i;
+  position_pid_params_ch1.d = pos_d;
   position_pid_params_ch1.output_ramp = 10000.0;
   position_pid_params_ch1.lpf_time_constant = 0.11;
 

--- a/examples/spin_2_motors.cpp
+++ b/examples/spin_2_motors.cpp
@@ -1,0 +1,91 @@
+#include <Arduino.h>
+
+#include "motorgo_mini.h"
+
+MotorGo::MotorGoMini* motorgo_mini;
+MotorGo::MotorParameters motor_params_ch0;
+MotorGo::MotorParameters motor_params_ch1;
+
+MotorGo::PIDParameters velocity_pid_params_ch0;
+MotorGo::PIDParameters velocity_pid_params_ch1;
+
+// Function to print at a maximum frequency
+void freq_println(String str, int freq)
+{
+  static unsigned long last_print_time = 0;
+  unsigned long now = millis();
+
+  if (now - last_print_time > 1000 / freq)
+  {
+    Serial.println(str);
+    last_print_time = now;
+  }
+}
+
+void setup()
+{
+  Serial.begin(115200);
+
+  // Setup motor parameters
+  motor_params_ch0.pole_pairs = 7;
+  motor_params_ch0.power_supply_voltage = 5.0;
+  motor_params_ch0.voltage_limit = 5.0;
+  motor_params_ch0.current_limit = 300;
+  motor_params_ch0.velocity_limit = 100.0;
+  motor_params_ch0.calibration_voltage = 2.0;
+
+  motor_params_ch1.pole_pairs = 7;
+  motor_params_ch1.power_supply_voltage = 5.0;
+  motor_params_ch1.voltage_limit = 5.0;
+  motor_params_ch1.current_limit = 300;
+  motor_params_ch1.velocity_limit = 100.0;
+  motor_params_ch1.calibration_voltage = 2.0;
+
+  // Instantiate motorgo mini board
+  motorgo_mini = new MotorGo::MotorGoMini();
+
+  // Setup Ch0 with FOCStudio enabled
+  bool calibrate = false;
+  bool enable_foc_studio = false;
+  motorgo_mini->init_ch0(motor_params_ch0, calibrate, enable_foc_studio);
+  motorgo_mini->init_ch1(motor_params_ch1, calibrate, enable_foc_studio);
+
+  // Set velocity controller parameters
+  // Setup PID parameters
+  velocity_pid_params_ch0.p = 4.0;
+  velocity_pid_params_ch0.i = 0.5;
+  velocity_pid_params_ch0.d = 0.0;
+  velocity_pid_params_ch0.output_ramp = 10000.0;
+  velocity_pid_params_ch0.lpf_time_constant = 0.1;
+
+  velocity_pid_params_ch1.p = 4.0;
+  velocity_pid_params_ch1.i = 0.5;
+  velocity_pid_params_ch1.d = 0.0;
+  velocity_pid_params_ch1.output_ramp = 10000.0;
+  velocity_pid_params_ch1.lpf_time_constant = 0.1;
+
+  motorgo_mini->set_velocity_controller_ch0(velocity_pid_params_ch0);
+  motorgo_mini->set_velocity_controller_ch1(velocity_pid_params_ch1);
+
+  //   Set closed-loop velocity mode
+  motorgo_mini->set_control_mode_ch0(MotorGo::ControlMode::Velocity);
+  motorgo_mini->set_control_mode_ch1(MotorGo::ControlMode::Velocity);
+
+  motorgo_mini->enable_ch0();
+  motorgo_mini->enable_ch1();
+}
+
+void loop()
+{
+  // Run Ch0
+  motorgo_mini->loop_ch0();
+  motorgo_mini->loop_ch1();
+
+  motorgo_mini->set_target_velocity_ch0(10.0);
+  motorgo_mini->set_target_velocity_ch1(10.0);
+
+  String str = "Velocity - Ch0: " + String(motorgo_mini->get_ch0_velocity()) +
+               " Ch1: " + String(motorgo_mini->get_ch1_velocity());
+
+  freq_println(str, 10);
+}

--- a/examples/spin_2_motors.cpp
+++ b/examples/spin_2_motors.cpp
@@ -52,17 +52,17 @@ void setup()
 
   // Set velocity controller parameters
   // Setup PID parameters
-  velocity_pid_params_ch0.p = 4.0;
-  velocity_pid_params_ch0.i = 0.5;
+  velocity_pid_params_ch0.p = 1.6;
+  velocity_pid_params_ch0.i = 0.01;
   velocity_pid_params_ch0.d = 0.0;
   velocity_pid_params_ch0.output_ramp = 10000.0;
-  velocity_pid_params_ch0.lpf_time_constant = 0.1;
+  velocity_pid_params_ch0.lpf_time_constant = 0.11;
 
-  velocity_pid_params_ch1.p = 4.0;
-  velocity_pid_params_ch1.i = 0.5;
+  velocity_pid_params_ch1.p = 1.6;
+  velocity_pid_params_ch1.i = 0.01;
   velocity_pid_params_ch1.d = 0.0;
   velocity_pid_params_ch1.output_ramp = 10000.0;
-  velocity_pid_params_ch1.lpf_time_constant = 0.1;
+  velocity_pid_params_ch1.lpf_time_constant = 0.11;
 
   motorgo_mini->set_velocity_controller_ch0(velocity_pid_params_ch0);
   motorgo_mini->set_velocity_controller_ch1(velocity_pid_params_ch1);

--- a/examples/tune_controllers.cpp
+++ b/examples/tune_controllers.cpp
@@ -1,0 +1,282 @@
+#include <Arduino.h>
+
+#include "configurable.h"
+#include "motorgo_mini.h"
+
+MotorGo::MotorGoMini* motorgo_mini;
+MotorGo::MotorParameters motor_params_ch0;
+MotorGo::MotorParameters motor_params_ch1;
+
+MotorGo::PIDParameters current_pid_params_ch0;
+MotorGo::PIDParameters current_pid_params_ch1;
+
+MotorGo::PIDParameters velocity_pid_params_ch0;
+MotorGo::PIDParameters velocity_pid_params_ch1;
+
+MotorGo::PIDParameters position_pid_params_ch0;
+MotorGo::PIDParameters position_pid_params_ch1;
+
+ESPWifiConfig::Configurable<float> current_p_ch0(
+    current_pid_params_ch0.p, "/ch0/current/p",
+    "P Gain for Channel 0 current controller");
+
+ESPWifiConfig::Configurable<float> current_i_ch0(
+    current_pid_params_ch0.i, "/ch0/current/i",
+    "I Gain for Channel 0 current controller");
+
+ESPWifiConfig::Configurable<float> current_d_ch0(
+    current_pid_params_ch0.d, "/ch0/current/d",
+    "D Gain for Channel 0 current controller");
+
+ESPWifiConfig::Configurable<float> current_lpf_ch0(
+    current_pid_params_ch0.lpf_time_constant, "/ch0/current/lpf",
+    "Low pass filter time constant for Channel 0 current controller");
+
+ESPWifiConfig::Configurable<float> current_p_ch1(
+    current_pid_params_ch1.p, "/ch1/current/p",
+    "P Gain for Channel 1 current controller");
+
+ESPWifiConfig::Configurable<float> current_i_ch1(
+    current_pid_params_ch1.i, "/ch1/current/i",
+    "I Gain for Channel 1 current controller");
+
+ESPWifiConfig::Configurable<float> current_d_ch1(
+    current_pid_params_ch1.d, "/ch1/current/d",
+    "D Gain for Channel 1 current controller");
+
+ESPWifiConfig::Configurable<float> current_lpf_ch1(
+    current_pid_params_ch1.lpf_time_constant, "/ch1/current/lpf",
+    "Low pass filter time constant for Channel 1 current controller");
+
+ESPWifiConfig::Configurable<float> velocity_p_ch0(
+    velocity_pid_params_ch0.p, "/ch0/velocity/p",
+    "P Gain for Channel 0 velocity controller");
+
+ESPWifiConfig::Configurable<float> velocity_i_ch0(
+    velocity_pid_params_ch0.i, "/ch0/velocity/i",
+    "I Gain for Channel 0 velocity controller");
+
+ESPWifiConfig::Configurable<float> velocity_d_ch0(
+    velocity_pid_params_ch0.d, "/ch0/velocity/d",
+    "D Gain for Channel 0 velocity controller");
+
+ESPWifiConfig::Configurable<float> velocity_lpf_ch0(
+    velocity_pid_params_ch0.lpf_time_constant, "/ch0/velocity/lpf",
+    "Low pass filter time constant for Channel 0 velocity controller");
+
+ESPWifiConfig::Configurable<float> velocity_p_ch1(
+    velocity_pid_params_ch1.p, "/ch1/velocity/p",
+    "P Gain for Channel 1 velocity controller");
+
+ESPWifiConfig::Configurable<float> velocity_i_ch1(
+    velocity_pid_params_ch1.i, "/ch1/velocity/i",
+    "I Gain for Channel 1 velocity controller");
+
+ESPWifiConfig::Configurable<float> velocity_d_ch1(
+    velocity_pid_params_ch1.d, "/ch1/velocity/d",
+    "D Gain for Channel 1 velocity controller");
+
+ESPWifiConfig::Configurable<float> velocity_lpf_ch1(
+    velocity_pid_params_ch1.lpf_time_constant, "/ch1/velocity/lpf",
+    "Low pass filter time constant for Channel 1 velocity controller");
+
+ESPWifiConfig::Configurable<float> position_p_ch0(
+    position_pid_params_ch0.p, "/ch0/position/p",
+    "P Gain for Channel 0 position controller");
+
+ESPWifiConfig::Configurable<float> position_i_ch0(
+    position_pid_params_ch0.i, "/ch0/position/i",
+    "I Gain for Channel 0 position controller");
+
+ESPWifiConfig::Configurable<float> position_d_ch0(
+    position_pid_params_ch0.d, "/ch0/position/d",
+    "D Gain for Channel 0 position controller");
+
+ESPWifiConfig::Configurable<float> position_lpf_ch0(
+    position_pid_params_ch0.lpf_time_constant, "/ch0/position/lpf",
+    "Low pass filter time constant for Channel 0 position controller");
+
+ESPWifiConfig::Configurable<float> position_p_ch1(
+    position_pid_params_ch1.p, "/ch1/position/p",
+    "P Gain for Channel 1 position controller");
+
+ESPWifiConfig::Configurable<float> position_i_ch1(
+    position_pid_params_ch1.i, "/ch1/position/i",
+    "I Gain for Channel 1 position controller");
+
+ESPWifiConfig::Configurable<float> position_d_ch1(
+    position_pid_params_ch1.d, "/ch1/position/d",
+    "D Gain for Channel 1 position controller");
+
+ESPWifiConfig::Configurable<float> position_lpf_ch1(
+    position_pid_params_ch1.lpf_time_constant, "/ch1/position/lpf",
+    "Low pass filter time constant for Channel 1 position controller");
+
+void position_pid_update_ch0(float value)
+{
+  motorgo_mini->disable_ch0();
+  motorgo_mini->set_position_controller_ch0(position_pid_params_ch0);
+
+  //   Reset position, velocity, and torque controllers;
+  motorgo_mini->reset_position_controller_ch0();
+  motorgo_mini->reset_velocity_controller_ch0();
+  motorgo_mini->reset_torque_controller_ch0();
+}
+
+void position_pid_update_ch1(float value)
+{
+  motorgo_mini->disable_ch1();
+  motorgo_mini->set_position_controller_ch1(position_pid_params_ch1);
+
+  //   Reset position, velocity, and torque controllers;
+  motorgo_mini->reset_position_controller_ch1();
+  motorgo_mini->reset_velocity_controller_ch1();
+  motorgo_mini->reset_torque_controller_ch1();
+}
+
+void velocity_pid_update_ch0(float value)
+{
+  motorgo_mini->disable_ch0();
+  motorgo_mini->set_velocity_controller_ch0(velocity_pid_params_ch0);
+
+  //   Reset velocity and torque controllers;
+  motorgo_mini->reset_velocity_controller_ch0();
+  motorgo_mini->reset_torque_controller_ch0();
+}
+
+void velocity_pid_update_ch1(float value)
+{
+  motorgo_mini->disable_ch1();
+  motorgo_mini->set_velocity_controller_ch1(velocity_pid_params_ch1);
+
+  //   Reset velocity and torque controllers;
+  motorgo_mini->reset_velocity_controller_ch1();
+  motorgo_mini->reset_torque_controller_ch1();
+}
+
+void current_pid_update_ch0(float value)
+{
+  motorgo_mini->disable_ch0();
+  motorgo_mini->set_torque_controller_ch0(current_pid_params_ch0);
+
+  //   Reset torque controller;
+  motorgo_mini->reset_torque_controller_ch0();
+}
+
+void current_pid_update_ch1(float value)
+{
+  motorgo_mini->disable_ch1();
+  motorgo_mini->set_torque_controller_ch1(current_pid_params_ch1);
+
+  //   Reset torque controller;
+  motorgo_mini->reset_torque_controller_ch1();
+}
+
+// Function to print at a maximum frequency
+void freq_println(String str, int freq)
+{
+  static unsigned long last_print_time = 0;
+  unsigned long now = millis();
+
+  if (now - last_print_time > 1000 / freq)
+  {
+    Serial.println(str);
+    last_print_time = now;
+  }
+}
+
+void setup()
+{
+  Serial.begin(115200);
+
+  //   Configure PID update callbacks
+  current_p_ch0.set_post_callback(current_pid_update_ch0);
+  current_i_ch0.set_post_callback(current_pid_update_ch0);
+  current_d_ch0.set_post_callback(current_pid_update_ch0);
+  current_lpf_ch0.set_post_callback(current_pid_update_ch0);
+
+  current_p_ch1.set_post_callback(current_pid_update_ch1);
+  current_i_ch1.set_post_callback(current_pid_update_ch1);
+  current_d_ch1.set_post_callback(current_pid_update_ch1);
+  current_lpf_ch1.set_post_callback(current_pid_update_ch1);
+
+  velocity_p_ch0.set_post_callback(velocity_pid_update_ch0);
+  velocity_i_ch0.set_post_callback(velocity_pid_update_ch0);
+  velocity_d_ch0.set_post_callback(velocity_pid_update_ch0);
+  velocity_lpf_ch0.set_post_callback(velocity_pid_update_ch0);
+
+  velocity_p_ch1.set_post_callback(velocity_pid_update_ch1);
+  velocity_i_ch1.set_post_callback(velocity_pid_update_ch1);
+  velocity_d_ch1.set_post_callback(velocity_pid_update_ch1);
+  velocity_lpf_ch1.set_post_callback(velocity_pid_update_ch1);
+
+  position_p_ch0.set_post_callback(position_pid_update_ch0);
+  position_i_ch0.set_post_callback(position_pid_update_ch0);
+  position_d_ch0.set_post_callback(position_pid_update_ch0);
+  position_lpf_ch0.set_post_callback(position_pid_update_ch0);
+
+  ESPWifiConfig::WebServer::getInstance().start();
+
+  // Setup motor parameters
+  motor_params_ch0.pole_pairs = 7;
+  motor_params_ch0.power_supply_voltage = 5.0;
+  motor_params_ch0.voltage_limit = 5.0;
+  motor_params_ch0.current_limit = 300;
+  motor_params_ch0.velocity_limit = 100.0;
+  motor_params_ch0.calibration_voltage = 2.0;
+
+  motor_params_ch1.pole_pairs = 7;
+  motor_params_ch1.power_supply_voltage = 5.0;
+  motor_params_ch1.voltage_limit = 5.0;
+  motor_params_ch1.current_limit = 300;
+  motor_params_ch1.velocity_limit = 100.0;
+  motor_params_ch1.calibration_voltage = 2.0;
+
+  // Instantiate motorgo mini board
+  motorgo_mini = new MotorGo::MotorGoMini();
+
+  // Setup Ch0 with FOCStudio enabled
+  bool calibrate = false;
+  bool enable_foc_studio = false;
+  motorgo_mini->init_ch0(motor_params_ch0, calibrate, enable_foc_studio);
+  motorgo_mini->init_ch1(motor_params_ch1, calibrate, enable_foc_studio);
+
+  // Set velocity controller parameters
+  // Setup PID parameters
+  velocity_pid_params_ch0.p = 4.0;
+  velocity_pid_params_ch0.i = 0.5;
+  velocity_pid_params_ch0.d = 0.0;
+  velocity_pid_params_ch0.output_ramp = 10000.0;
+  velocity_pid_params_ch0.lpf_time_constant = 0.1;
+
+  velocity_pid_params_ch1.p = 4.0;
+  velocity_pid_params_ch1.i = 0.5;
+  velocity_pid_params_ch1.d = 0.0;
+  velocity_pid_params_ch1.output_ramp = 10000.0;
+  velocity_pid_params_ch1.lpf_time_constant = 0.1;
+
+  motorgo_mini->set_velocity_controller_ch0(velocity_pid_params_ch0);
+  motorgo_mini->set_velocity_controller_ch1(velocity_pid_params_ch1);
+
+  //   Set closed-loop velocity mode
+  motorgo_mini->set_control_mode_ch0(MotorGo::ControlMode::Velocity);
+  motorgo_mini->set_control_mode_ch1(MotorGo::ControlMode::Velocity);
+
+  motorgo_mini->enable_ch0();
+  motorgo_mini->enable_ch1();
+}
+
+void loop()
+{
+  // Run Ch0
+  motorgo_mini->loop_ch0();
+  motorgo_mini->loop_ch1();
+
+  motorgo_mini->set_target_velocity_ch0(10.0);
+  motorgo_mini->set_target_velocity_ch1(10.0);
+
+  String str = "Velocity - Ch0: " + String(motorgo_mini->get_ch0_velocity()) +
+               " Ch1: " + String(motorgo_mini->get_ch1_velocity());
+
+  freq_println(str, 10);
+}

--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -82,6 +82,15 @@ class MotorGoMini
   void set_position_controller_ch0(PIDParameters params);
   void set_position_controller_ch1(PIDParameters params);
 
+  void reset_torque_controller_ch0();
+  void reset_torque_controller_ch1();
+
+  void reset_velocity_controller_ch0();
+  void reset_velocity_controller_ch1();
+
+  void reset_position_controller_ch0();
+  void reset_position_controller_ch1();
+
   // Enable and disable motors
   void enable_ch0();
   void enable_ch1();

--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -137,6 +137,10 @@ class MotorGoMini
   void set_target_position_ch0(float target);
   void set_target_position_ch1(float target);
 
+  // Set target voltage
+  void set_target_voltage_ch0(float target);
+  void set_target_voltage_ch1(float target);
+
   void save_torque_controller_ch0();
   void save_torque_controller_ch1();
   void load_torque_controller_ch0();
@@ -191,7 +195,7 @@ class MotorGoMini
   const int k_ch1_gpio_vl = 21;
   const int k_ch1_gpio_wh = 11;
   const int k_ch1_gpio_wl = 14;
-  const int k_ch1_current_u = 47;
+  const int k_ch1_current_u = 8;
   const int k_ch1_current_w = 12;
 
   // Additional motor and encoder parameters

--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -35,6 +35,21 @@ struct PIDParameters
   float limit = 10000.0f;
 };
 
+typedef union
+{
+  struct __attribute__((packed))
+  {
+    float p;
+    float i;
+    float d;
+    float output_ramp;
+    float lpf_time_constant;
+    float limit;
+  };
+
+  uint8_t raw[sizeof(PIDParameters)];
+} packed_pid_parameters_t;
+
 struct MotorParameters
 {
   int pole_pairs;
@@ -72,6 +87,15 @@ class MotorGoMini
   // Run control loop, should be called at fixed frequency
   void loop_ch0();
   void loop_ch1();
+
+  PIDParameters get_torque_controller_ch0();
+  PIDParameters get_torque_controller_ch1();
+
+  PIDParameters get_velocity_controller_ch0();
+  PIDParameters get_velocity_controller_ch1();
+
+  PIDParameters get_position_controller_ch0();
+  PIDParameters get_position_controller_ch1();
 
   void set_torque_controller_ch0(PIDParameters params);
   void set_torque_controller_ch1(PIDParameters params);
@@ -112,6 +136,21 @@ class MotorGoMini
   // Set target position
   void set_target_position_ch0(float target);
   void set_target_position_ch1(float target);
+
+  void save_torque_controller_ch0();
+  void save_torque_controller_ch1();
+  void load_torque_controller_ch0();
+  void load_torque_controller_ch1();
+
+  void save_velocity_controller_ch0();
+  void save_velocity_controller_ch1();
+  void load_velocity_controller_ch0();
+  void load_velocity_controller_ch1();
+
+  void save_position_controller_ch0();
+  void save_position_controller_ch1();
+  void load_position_controller_ch0();
+  void load_position_controller_ch1();
 
   // Zero Position
   void zero_position_ch0();
@@ -230,6 +269,9 @@ class MotorGoMini
   void set_target_helper_ch0();
   void set_target_helper_ch1();
 
+  void save_controller_helper(const char* key,
+                              const packed_pid_parameters_t& packed_params);
+  packed_pid_parameters_t load_controller_helper(const char* key);
   void set_torque_controller_helper(BLDCMotor& motor, PIDParameters params);
   void set_velocity_controller_helper(BLDCMotor& motor, PIDParameters params);
   void set_position_controller_helper(BLDCMotor& motor, PIDParameters params);

--- a/include/pid_manager.h
+++ b/include/pid_manager.h
@@ -1,0 +1,109 @@
+// Header file for the MotorGo Mini driver class.
+
+#ifndef PID_MANAGER_H
+#define PID_MANAGER_H
+
+#include "Arduino_JSON.h"
+#include "configurable.h"
+#include "motorgo_mini.h"
+#include "readable.h"
+
+template <>
+struct ESPWifiConfig::JsonConverter<MotorGo::PIDParameters>
+{
+  static MotorGo::PIDParameters convert(JSONVar obj)
+  {
+    MotorGo::PIDParameters params;
+
+    JSONVar p_var = JSONVar("p");
+    if (JSON.typeof(obj[p_var]) == "number")
+    {
+      params.p = static_cast<float>((double)obj[p_var]);
+    }
+    JSONVar i_var = JSONVar("i");
+    if (JSON.typeof(obj[i_var]) == "number")
+    {
+      params.i = static_cast<float>((double)obj[i_var]);
+    }
+    JSONVar d_var = JSONVar("d");
+    if (JSON.typeof(obj[d_var]) == "number")
+    {
+      params.d = static_cast<float>((double)obj[d_var]);
+    }
+    JSONVar output_ramp_var = JSONVar("output_ramp");
+    if (JSON.typeof(obj[output_ramp_var]) == "number")
+    {
+      params.output_ramp = static_cast<float>((double)obj[output_ramp_var]);
+    }
+    JSONVar lpf_time_constant_var = JSONVar("lpf_time_constant");
+    if (JSON.typeof(obj[lpf_time_constant_var]) == "number")
+    {
+      params.lpf_time_constant =
+          static_cast<float>((double)obj[lpf_time_constant_var]);
+    }
+    JSONVar limit_var = JSONVar("limit");
+    if (JSON.typeof(obj[limit_var]) == "number")
+    {
+      params.limit = static_cast<float>((double)obj[limit_var]);
+    }
+
+    return params;
+  }
+};
+
+template <>
+struct ESPWifiConfig::JsonSerializer<MotorGo::PIDParameters>
+{
+  static JSONVar serialize(const MotorGo::PIDParameters& obj)
+  {
+    JSONVar params;
+    params["p"] = obj.p;
+    params["i"] = obj.i;
+    params["d"] = obj.d;
+    params["output_ramp"] = obj.output_ramp;
+    params["lpf_time_constant"] = obj.lpf_time_constant;
+    params["limit"] = obj.limit;
+
+    return params;
+  }
+};
+
+namespace MotorGo
+{
+
+struct PIDManagerConfig
+{
+  String name;
+  PIDParameters& params;
+  std::function<void()> update_controller_callback;
+  ESPWifiConfig::Configurable<PIDParameters> configurable;
+
+  PIDManagerConfig(const String& name, PIDParameters& params_old,
+                   std::function<void()> callback);
+
+  PIDManagerConfig(const PIDManagerConfig& other);
+};
+
+class PIDManager
+{
+ public:
+  PIDManager();
+
+  // Adds a controller to the PIDManager
+  // add_controller takes a PIDParameters struct and a callback function to
+  // update the controller
+  void add_controller(String name, PIDParameters& params,
+                      std::function<void()> update_controller_callback);
+  void init();
+
+ private:
+  //  Vector of params
+  std::vector<PIDManagerConfig> configs;
+  JSONVar schema;
+
+  ESPWifiConfig::Readable<JSONVar> schema_readable;
+  void generate_schema();
+};
+}  // namespace MotorGo
+
+#endif  // MOTORGO_MINI_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,4 @@
-; PlatformIO Project Configuration File
+    ; PlatformIO Project Configuration File
 ;
 ;   Build options: build flags, source filter
 ;   Upload options: custom upload port, speed and extra flags

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,38 +9,85 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 
-[env:test]
+[env]
 platform = platformio/espressif32@^6.1.0
 board = esp32-s3-motorgo-mini
 framework = arduino
 lib_archive = no
 monitor_speed = 115200
 build_src_filter = +<motorgo_mini.cpp>
-                   +<main.cpp>
-
 lib_deps =
-    Preferences
-	askuric/Simple FOC@^2.3.0
+	askuric/Simple FOC@^2.3.1
 	https://github.com/Every-Flavor-Robotics/Arduino-FOC-drivers.git
-	https://github.com/Every-Flavor-Robotics/Arduino-FOC-drivers.git
+	https://github.com/Every-Flavor-Robotics/esp-options.git
     Wire
     SPI
 
+[env:test]
+build_src_filter = +<main.cpp>
 
+[env:test_leader]
+build_src_filter = +<leader.cpp>
+                   +<motorgo_group_leader.cpp>
+                   +<esp_now_comms.cpp>
+                   +<motorgo_comms_types.cpp>
 
-[env:test_esp]
-platform = platformio/espressif32@^6.1.0
-board = esp32dev
-framework = arduino
-lib_archive = no
-monitor_speed = 115200
-build_src_filter = +<motorgo_mini.cpp>
-                   +<main.cpp>
+lib_deps =
+    https://github.com/arduino-libraries/Arduino_JSON.git
+
+[env:test_follower]
+build_src_filter = +<follower.cpp>
+                   +<motorgo_groupie.cpp>
+                   +<esp_now_comms.cpp>
+                   +<motorgo_comms_types.cpp>
 
 lib_deps =
     Preferences
-	askuric/Simple FOC@^2.3.0
+	https://github.com/simplefoc/Arduino-FOC.git
 	https://github.com/Every-Flavor-Robotics/Arduino-FOC-drivers.git
-	https://github.com/Every-Flavor-Robotics/Arduino-FOC-drivers.git
+	https://github.com/Every-Flavor-Robotics/esp-options.git
     Wire
     SPI
+
+[env:example_tune_contollers]
+build_src_filter = ${env.build_src_filter} +<../examples/tune_controllers.cpp>
+build_flags =
+    -D WIFI_SSID=\"${sysenv.WIFI_SSID_ENV_VAR}\"
+    -D WIFI_PASSWORD=\"${sysenv.WIFI_PASSWORD_ENV_VAR}\"
+
+lib_deps =
+    ${env.lib_deps}
+    FS
+    https://github.com/Every-Flavor-Robotics/esp-wifi-config.git#feature/configurable-manager
+
+[env:spin_two_motors]
+build_src_filter = ${env.build_src_filter} +<../examples/spin_2_motors.cpp>
+build_flags =
+    -D WIFI_SSID=\"${sysenv.WIFI_SSID_ENV_VAR}\"
+    -D WIFI_PASSWORD=\"${sysenv.WIFI_PASSWORD_ENV_VAR}\"
+
+[env:haptics]
+build_src_filter = ${env.build_src_filter} +<../examples/haptics_demo.cpp>
+build_flags =
+    -D WIFI_SSID=\"${sysenv.WIFI_SSID_ENV_VAR}\"
+    -D WIFI_PASSWORD=\"${sysenv.WIFI_PASSWORD_ENV_VAR}\"
+
+lib_deps =
+    ${env.lib_deps}
+    FS
+    https://github.com/Every-Flavor-Robotics/esp-wifi-config.git#feature/configurable-manager
+
+
+[env:balance_bot]
+build_src_filter = ${env.build_src_filter} +<../examples/balance_bot.cpp> +<pid_manager.cpp>
+build_flags =
+    -D WIFI_SSID=\"${sysenv.WIFI_SSID_ENV_VAR}\"
+    -D WIFI_PASSWORD=\"${sysenv.WIFI_PASSWORD_ENV_VAR}\"
+
+lib_deps =
+    ${env.lib_deps}
+    FS
+    https://github.com/Every-Flavor-Robotics/esp-wifi-config.git#feature/configurable-manager
+    https://github.com/Every-Flavor-Robotics/mpu6050-driver.git
+
+

--- a/src/motorgo_mini.cpp
+++ b/src/motorgo_mini.cpp
@@ -764,6 +764,18 @@ void MotorGo::MotorGoMini::set_target_position_ch1(float target)
   set_target_helper_ch1();
 }
 
+void MotorGo::MotorGoMini::set_target_voltage_ch0(float target)
+{
+  target_voltage_ch0 = target;
+  set_target_helper_ch0();
+}
+
+void MotorGo::MotorGoMini::set_target_voltage_ch1(float target)
+{
+  target_voltage_ch1 = target;
+  set_target_helper_ch1();
+}
+
 void MotorGo::MotorGoMini::zero_position_ch0()
 {
   MotorGo::motor_ch0.sensor_offset = MotorGo::motor_ch0.shaftAngle();

--- a/src/motorgo_mini.cpp
+++ b/src/motorgo_mini.cpp
@@ -417,6 +417,36 @@ void MotorGo::MotorGoMini::set_position_controller_ch1(
   pid_position_ch1_enabled = true;
 }
 
+void MotorGo::MotorGoMini::reset_torque_controller_ch0()
+{
+  MotorGo::motor_ch0.PID_current_q.reset();
+}
+
+void MotorGo::MotorGoMini::reset_torque_controller_ch1()
+{
+  MotorGo::motor_ch1.PID_current_q.reset();
+}
+
+void MotorGo::MotorGoMini::reset_velocity_controller_ch0()
+{
+  MotorGo::motor_ch0.PID_velocity.reset();
+}
+
+void MotorGo::MotorGoMini::reset_velocity_controller_ch1()
+{
+  MotorGo::motor_ch1.PID_velocity.reset();
+}
+
+void MotorGo::MotorGoMini::reset_position_controller_ch0()
+{
+  MotorGo::motor_ch0.P_angle.reset();
+}
+
+void MotorGo::MotorGoMini::reset_position_controller_ch1()
+{
+  MotorGo::motor_ch1.P_angle.reset();
+}
+
 void MotorGo::MotorGoMini::enable_ch0() { MotorGo::motor_ch0.enable(); }
 void MotorGo::MotorGoMini::enable_ch1() { MotorGo::motor_ch1.enable(); }
 void MotorGo::MotorGoMini::disable_ch0() { MotorGo::motor_ch0.disable(); }

--- a/src/pid_manager.cpp
+++ b/src/pid_manager.cpp
@@ -1,0 +1,75 @@
+#include "pid_manager.h"
+
+#include "web_server.h"
+
+MotorGo::PIDManagerConfig::PIDManagerConfig(const String& name,
+                                            PIDParameters& params,
+                                            std::function<void()> callback)
+    : name(name),
+      params(params),
+      update_controller_callback(callback),
+      configurable(this->params, "/pid" + name, "PID Controller")
+{
+}
+
+MotorGo::PIDManagerConfig::PIDManagerConfig(const PIDManagerConfig& other)
+    : name(other.name),
+      params(other.params),  // Copying the reference
+      update_controller_callback(other.update_controller_callback),
+      configurable(other.configurable)
+{
+}
+
+MotorGo::PIDManager::PIDManager() {}
+
+void MotorGo::PIDManager::add_controller(
+    String name, PIDParameters& params,
+    std::function<void()> update_controller_callback)
+{
+  PIDManagerConfig config(name, params, update_controller_callback);
+  configs.push_back(config);
+}
+
+void MotorGo::PIDManager::init()
+{
+  Serial.println("Initializing PIDManager");
+  for (auto& config : configs)
+  {
+    config.configurable.set_post_callback(
+        [this, &config](PIDParameters params)
+        { config.update_controller_callback(); });
+
+    Serial.println(config.configurable.get_endpoint());
+  }
+
+  generate_schema();
+
+  schema_readable = ESPWifiConfig::Readable<JSONVar>(
+      [this]() { return schema; }, "/pid/schema",
+      "Description of available PID controllers");
+
+  ESPWifiConfig::WebServer::getInstance().start();
+
+  //   Display URL to access webserver. http://{ip_address}:{port}
+  Serial.println("Webserver available at:");
+  Serial.print("http://");
+  Serial.print(ESPWifiConfig::WebServer::getInstance().get_ip_address());
+  Serial.print(":");
+  Serial.println(ESPWifiConfig::WebServer::getInstance().get_port());
+}
+
+void MotorGo::PIDManager::generate_schema()
+{
+  // Generate API schema
+  // A list of controller endpoints, each with an associated description
+
+  schema = JSONVar();
+
+  for (size_t i = 0; i < configs.size(); i++)
+  {
+    JSONVar endpoint;
+    endpoint["endpoint"] = configs[i].configurable.get_endpoint();
+    endpoint["name"] = configs[i].name;
+    schema[i] = endpoint;
+  }
+}


### PR DESCRIPTION
Wrote sample code for the following example projects:
* Spinning and calibrating 2 motors
* Two way haptic knob
* Balance bot

In the process of getting these demos working, the following features were also implemented:
* PID Manager to handle automatically populating PID tuners in the MotorGo web GUI
* Updated pin definitions to correctly setup GPIO pins for MotorGo Mini V1 Rev 2
* Implemented set_target_voltage fuinction

With this PR, the haptics demo does not currently implement the PID Manager to populate tuners in the Web GUI