### PR TITLE
Added missing dependencies, upgraded SimpleFOC version

### DIFF
--- a/library.json
+++ b/library.json
@@ -43,5 +43,9 @@
             "name": "Preferences",
             "version": "*"
         }
+        {
+            "name": "Arduino_JSON",
+            "version": "https://github.com/arduino-libraries/Arduino_JSON.git"
+        }
     ]
 }

--- a/library.json
+++ b/library.json
@@ -29,7 +29,11 @@
         },
         {
             "name": "ESP-Options",
-            "version": "https://github.com/Roam-Studios/esp-options.git"
+            "version": "https://github.com/Every-Flavor-Robotics/esp-options.git"
+        },
+        {
+            "name": "ESPWifiConfig",
+            "version": "https://github.com/Every-Flavor-Robotics/esp-wifi-config.git#feature/configurable-manager"
         },
         {
             "name": "Wire",
@@ -41,6 +45,10 @@
         },
         {
             "name": "Preferences",
+            "version": "*"
+        },
+        {
+            "name": "FS",
             "version": "*"
         },
         {

--- a/library.json
+++ b/library.json
@@ -42,7 +42,7 @@
         {
             "name": "Preferences",
             "version": "*"
-        }
+        },
         {
             "name": "Arduino_JSON",
             "version": "https://github.com/arduino-libraries/Arduino_JSON.git"

--- a/library.json
+++ b/library.json
@@ -21,15 +21,27 @@
         {
             "owner": "askuric",
             "name": "Simple FOC",
-            "version": "^2.3.0"
+            "version": "^2.3.2"
         },
         {
             "name": "SimpleFOCDrivers",
-            "version": "https://github.com/Roam-Studios/Arduino-FOC-drivers.git#ccw-bug-fix"
+            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC-drivers.git"
         },
         {
             "name": "ESP-Options",
             "version": "https://github.com/Roam-Studios/esp-options.git"
+        },
+        {
+            "name": "Wire",
+            "version": "*"
+        },
+        {
+            "name": "SPI",
+            "version": "*"
+        },
+        {
+            "name": "Preferences",
+            "version": "*"
         }
     ]
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ lib_archive = no
 monitor_speed = 115200
 build_src_filter = +<motorgo_mini.cpp>
 lib_deps =
-	askuric/Simple FOC@^2.3.1
+	askuric/Simple FOC@^2.3.2
 	https://github.com/Every-Flavor-Robotics/Arduino-FOC-drivers.git
 	https://github.com/Every-Flavor-Robotics/esp-options.git
     Wire


### PR DESCRIPTION
Closes #33, adds Wire, SPI, and Preferences to the library dependencies in `library.json`. 

Upgrades the SimpleFOC version to 2.3.2, which addresses ADC initialization bugs for the ESP32S3, which has blocked progress on current sensing support.