### PR TITLE
Remove the need for environment variables containing wifi credentials

### DIFF
--- a/examples/balance_bot.cpp
+++ b/examples/balance_bot.cpp
@@ -8,6 +8,10 @@
 #include "pid_manager.h"
 #include "sensorgo_mpu6050.h"
 
+// UPDATE THESE VALUES
+String WIFI_SSID = "YOUR_SSID";
+String WIFI_PASSWORD = "YOUR_PASSWORD";
+
 MotorGo::MotorGoMini* motorgo_mini;
 MotorGo::MotorParameters motor_params_ch0;
 MotorGo::MotorParameters motor_params_ch1;
@@ -207,7 +211,7 @@ void setup()
   enable_motors.set_post_callback(enable_motors_callback);
 
   // initialize the PID manager
-  pid_manager.init();
+  pid_manager.init(WIFI_SSID, WIFI_PASSWORD);
 
   initial_angle_ch0 = motorgo_mini->get_ch0_position();
   initial_angle_ch1 = motorgo_mini->get_ch1_position();

--- a/examples/haptics_demo.cpp
+++ b/examples/haptics_demo.cpp
@@ -4,6 +4,10 @@
 #include "motorgo_mini.h"
 #include "pid_manager.h"
 
+// UPDATE THESE VALUES
+String WIFI_SSID = "YOUR_SSID";
+String WIFI_PASSWORD = "YOUR_PASSWORD";
+
 MotorGo::MotorGoMini* motorgo_mini;
 MotorGo::MotorParameters motor_params_ch0;
 MotorGo::MotorParameters motor_params_ch1;
@@ -122,7 +126,7 @@ void setup()
   enable_motors.set_post_callback(enable_motors_callback);
 
   // initialize the PID manager
-  pid_manager.init();
+  pid_manager.init(WIFI_SSID, WIFI_PASSWORD);
 
   //   Set closed-loop position mode
   motorgo_mini->set_control_mode_ch0(MotorGo::ControlMode::Position);

--- a/include/pid_manager.h
+++ b/include/pid_manager.h
@@ -94,7 +94,7 @@ class PIDManager
   // update the controller
   void add_controller(String name, PIDParameters& params,
                       std::function<void()> update_controller_callback);
-  void init();
+  void init(String wifi_ssid, String wifi_password);
 
  private:
   //  Vector of params

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,16 +15,17 @@ board = esp32-s3-motorgo-mini
 framework = arduino
 lib_archive = no
 monitor_speed = 115200
-build_src_filter = +<motorgo_mini.cpp>
+build_src_filter = +<*.cpp>
 lib_deps =
+    Preferences
 	askuric/Simple FOC@^2.3.2
 	https://github.com/Every-Flavor-Robotics/Arduino-FOC-drivers.git
 	https://github.com/Every-Flavor-Robotics/esp-options.git
+    https://github.com/arduino-libraries/Arduino_JSON.git
+    https://github.com/Every-Flavor-Robotics/esp-wifi-config.git#feature/configurable-manager
     Wire
     SPI
-
-[env:test]
-build_src_filter = +<main.cpp>
+    FS
 
 [env:test_leader]
 build_src_filter = +<leader.cpp>
@@ -32,28 +33,14 @@ build_src_filter = +<leader.cpp>
                    +<esp_now_comms.cpp>
                    +<motorgo_comms_types.cpp>
 
-lib_deps =
-    https://github.com/arduino-libraries/Arduino_JSON.git
-
 [env:test_follower]
 build_src_filter = +<follower.cpp>
                    +<motorgo_groupie.cpp>
                    +<esp_now_comms.cpp>
                    +<motorgo_comms_types.cpp>
 
-lib_deps =
-    Preferences
-	https://github.com/simplefoc/Arduino-FOC.git
-	https://github.com/Every-Flavor-Robotics/Arduino-FOC-drivers.git
-	https://github.com/Every-Flavor-Robotics/esp-options.git
-    Wire
-    SPI
-
 [env:example_tune_contollers]
 build_src_filter = ${env.build_src_filter} +<../examples/tune_controllers.cpp>
-build_flags =
-    -D WIFI_SSID=\"${sysenv.WIFI_SSID_ENV_VAR}\"
-    -D WIFI_PASSWORD=\"${sysenv.WIFI_PASSWORD_ENV_VAR}\"
 
 lib_deps =
     ${env.lib_deps}
@@ -62,33 +49,16 @@ lib_deps =
 
 [env:spin_two_motors]
 build_src_filter = ${env.build_src_filter} +<../examples/spin_2_motors.cpp>
-build_flags =
-    -D WIFI_SSID=\"${sysenv.WIFI_SSID_ENV_VAR}\"
-    -D WIFI_PASSWORD=\"${sysenv.WIFI_PASSWORD_ENV_VAR}\"
 
 [env:haptics]
-build_src_filter = ${env.build_src_filter} +<../examples/haptics_demo.cpp> +<pid_manager.cpp>
-build_flags =
-    -D WIFI_SSID=\"${sysenv.WIFI_SSID_ENV_VAR}\"
-    -D WIFI_PASSWORD=\"${sysenv.WIFI_PASSWORD_ENV_VAR}\"
-
-lib_deps =
-    ${env.lib_deps}
-    FS
-    https://github.com/Every-Flavor-Robotics/esp-wifi-config.git#feature/configurable-manager
-
+build_src_filter = ${env.build_src_filter} +<../examples/haptics_demo.cpp>
 
 
 [env:balance_bot]
-build_src_filter = ${env.build_src_filter} +<../examples/balance_bot.cpp> +<pid_manager.cpp>
-build_flags =
-    -D WIFI_SSID=\"${sysenv.WIFI_SSID_ENV_VAR}\"
-    -D WIFI_PASSWORD=\"${sysenv.WIFI_PASSWORD_ENV_VAR}\"
+build_src_filter = ${env.build_src_filter} +<../examples/balance_bot.cpp>
 
 lib_deps =
     ${env.lib_deps}
-    FS
-    https://github.com/Every-Flavor-Robotics/esp-wifi-config.git#feature/configurable-manager
     https://github.com/Every-Flavor-Robotics/mpu6050-driver.git
 
 

--- a/src/pid_manager.cpp
+++ b/src/pid_manager.cpp
@@ -30,7 +30,7 @@ void MotorGo::PIDManager::add_controller(
   configs.push_back(config);
 }
 
-void MotorGo::PIDManager::init()
+void MotorGo::PIDManager::init(String wifi_ssid, String wifi_password)
 {
   Serial.println("Initializing PIDManager");
   for (auto& config : configs)
@@ -48,7 +48,7 @@ void MotorGo::PIDManager::init()
       [this]() { return schema; }, "/pid/schema",
       "Description of available PID controllers");
 
-  ESPWifiConfig::WebServer::getInstance().start();
+  ESPWifiConfig::WebServer::getInstance().start(wifi_ssid, wifi_password);
 
   //   Display URL to access webserver. http://{ip_address}:{port}
   Serial.println("Webserver available at:");


### PR DESCRIPTION
Closes #37 . The web server if esp-wifi-config was updated to take the wifi credentials as arguments to `start()`. MotorGo Mini driver was updated to match this updated.

This change improves the user for the software because:
* The user does not need to specify wifi credentials unless they are using the pid_manager
* The user does not need to set environment variables including the wifi credentials

However, the user does now need to be careful not to commit wifi credentials to Github from their code. This is a temporary issue until a better wifi config routine is designed.