### PR TITLE
Add support to blink LED with network activity in esp-wifi-config package

### DIFF
--- a/src/pid_manager.cpp
+++ b/src/pid_manager.cpp
@@ -48,7 +48,8 @@ void MotorGo::PIDManager::init(String wifi_ssid, String wifi_password)
       [this]() { return schema; }, "/pid/schema",
       "Description of available PID controllers");
 
-  ESPWifiConfig::WebServer::getInstance().start(wifi_ssid, wifi_password);
+  ESPWifiConfig::WebServer::getInstance().start(wifi_ssid, wifi_password,
+                                                LED_NETWORK);
 
   //   Display URL to access webserver. http://{ip_address}:{port}
   Serial.println("Webserver available at:");


### PR DESCRIPTION
* Updated call to WebServer.start() to pass LED_NETWORK.

Tested on hardware.