### PR TITLE
syntax, controllers work with updated calibration, optional balance p…

### DIFF
--- a/examples/balance_bot/src/balance_bot.cpp
+++ b/examples/balance_bot/src/balance_bot.cpp
@@ -9,8 +9,8 @@
 #include "sensorgo_mpu6050.h"
 
 // UPDATE THESE VALUES
-String WIFI_SSID = "WIFI_SSID";
-String WIFI_PASSWORD = "WIFI_PASSWORD";
+String WIFI_SSID = "YOUR_SSID";
+String WIFI_PASSWORD = "YOUR_PASSWORD";
 
 MotorGo::MotorGoMini motorgo_mini;
 MotorGo::MotorChannel& motor_left = motorgo_mini.ch0;


### PR DESCRIPTION
**changelog** 
- made balance bot work with new motor calibration standard. (fixed +/- signs) 
- syntax fix (missing semicolon)
- added optional (commented out) PID controller, where the P value updates the balance point of the robot in real time. 

closes #50 
