### PR TITLE
Fixed failing balance bot build

### DIFF
--- a/examples/balance_bot/platformio.ini
+++ b/examples/balance_bot/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 
-[env:calibrate_motors]
+[env:balance_bot]
 platform = platformio/espressif32@^6.1.0
 board = motorgo-mini-v1.2
 framework = arduino
@@ -18,7 +18,7 @@ monitor_speed = 115200
 build_src_filter = +<*.cpp>
 lib_deps =
     https://github.com/Every-Flavor-Robotics/motorgo-mini-driver.git#dev
-    https://github.com/Every-Flavor-Robotics/mpu6050-driver.git
+    https://github.com/Every-Flavor-Robotics/mpu6050-driver.git#0.1
 
 
 

--- a/examples/tune_controllers/src/tune_controllers.cpp
+++ b/examples/tune_controllers/src/tune_controllers.cpp
@@ -3,8 +3,12 @@
 
 #include "configurable.h"
 #include "motorgo_mini.h"
-#include "readable.h"
+#include "pid_manager.h"
 #include "web_server.h"
+
+// UPDATE THESE VALUES
+String WIFI_SSID = "YOUR_SSID";
+String WIFI_PASSWORD = "YOUR_PASSWORD";
 
 MotorGo::MotorGoMini motorgo_mini;
 MotorGo::MotorChannel& motor_ch0 = motorgo_mini.ch0;
@@ -22,226 +26,27 @@ MotorGo::PIDParameters velocity_pid_params_ch1;
 MotorGo::PIDParameters position_pid_params_ch0;
 MotorGo::PIDParameters position_pid_params_ch1;
 
-ESPWifiConfig::Configurable<float> current_p_ch0(
-    current_pid_params_ch0.p, "/ch0/current/p",
-    "P Gain for Channel 0 current controller");
+// declare PID manager object
+MotorGo::PIDManager pid_manager;
 
-ESPWifiConfig::Configurable<float> current_i_ch0(
-    current_pid_params_ch0.i, "/ch0/current/i",
-    "I Gain for Channel 0 current controller");
+bool motors_enabled = false;
+ESPWifiConfig::Configurable<bool> enable_motors(motors_enabled, "/enable",
+                                                "Enable motors");
 
-ESPWifiConfig::Configurable<float> current_d_ch0(
-    current_pid_params_ch0.d, "/ch0/current/d",
-    "D Gain for Channel 0 current controller");
-
-ESPWifiConfig::Configurable<float> current_lpf_ch0(
-    current_pid_params_ch0.lpf_time_constant, "/ch0/current/lpf",
-    "Low pass filter time constant for Channel 0 current controller");
-
-ESPWifiConfig::Configurable<float> current_p_ch1(
-    current_pid_params_ch1.p, "/ch1/current/p",
-    "P Gain for Channel 1 current controller");
-
-ESPWifiConfig::Configurable<float> current_i_ch1(
-    current_pid_params_ch1.i, "/ch1/current/i",
-    "I Gain for Channel 1 current controller");
-
-ESPWifiConfig::Configurable<float> current_d_ch1(
-    current_pid_params_ch1.d, "/ch1/current/d",
-    "D Gain for Channel 1 current controller");
-
-ESPWifiConfig::Configurable<float> current_lpf_ch1(
-    current_pid_params_ch1.lpf_time_constant, "/ch1/current/lpf",
-    "Low pass filter time constant for Channel 1 current controller");
-
-ESPWifiConfig::Configurable<float> velocity_p_ch0(
-    velocity_pid_params_ch0.p, "/ch0/velocity/p",
-    "P Gain for Channel 0 velocity controller");
-
-ESPWifiConfig::Configurable<float> velocity_i_ch0(
-    velocity_pid_params_ch0.i, "/ch0/velocity/i",
-    "I Gain for Channel 0 velocity controller");
-
-ESPWifiConfig::Configurable<float> velocity_d_ch0(
-    velocity_pid_params_ch0.d, "/ch0/velocity/d",
-    "D Gain for Channel 0 velocity controller");
-
-ESPWifiConfig::Configurable<float> velocity_lpf_ch0(
-    velocity_pid_params_ch0.lpf_time_constant, "/ch0/velocity/lpf",
-    "Low pass filter time constant for Channel 0 velocity controller");
-
-ESPWifiConfig::Configurable<float> velocity_p_ch1(
-    velocity_pid_params_ch1.p, "/ch1/velocity/p",
-    "P Gain for Channel 1 velocity controller");
-
-ESPWifiConfig::Configurable<float> velocity_i_ch1(
-    velocity_pid_params_ch1.i, "/ch1/velocity/i",
-    "I Gain for Channel 1 velocity controller");
-
-ESPWifiConfig::Configurable<float> velocity_d_ch1(
-    velocity_pid_params_ch1.d, "/ch1/velocity/d",
-    "D Gain for Channel 1 velocity controller");
-
-ESPWifiConfig::Configurable<float> velocity_lpf_ch1(
-    velocity_pid_params_ch1.lpf_time_constant, "/ch1/velocity/lpf",
-    "Low pass filter time constant for Channel 1 velocity controller");
-
-ESPWifiConfig::Configurable<float> position_p_ch0(
-    position_pid_params_ch0.p, "/ch0/position/p",
-    "P Gain for Channel 0 position controller");
-
-ESPWifiConfig::Configurable<float> position_i_ch0(
-    position_pid_params_ch0.i, "/ch0/position/i",
-    "I Gain for Channel 0 position controller");
-
-ESPWifiConfig::Configurable<float> position_d_ch0(
-    position_pid_params_ch0.d, "/ch0/position/d",
-    "D Gain for Channel 0 position controller");
-
-ESPWifiConfig::Configurable<float> position_lpf_ch0(
-    position_pid_params_ch0.lpf_time_constant, "/ch0/position/lpf",
-    "Low pass filter time constant for Channel 0 position controller");
-
-ESPWifiConfig::Configurable<float> position_p_ch1(
-    position_pid_params_ch1.p, "/ch1/position/p",
-    "P Gain for Channel 1 position controller");
-
-ESPWifiConfig::Configurable<float> position_i_ch1(
-    position_pid_params_ch1.i, "/ch1/position/i",
-    "I Gain for Channel 1 position controller");
-
-ESPWifiConfig::Configurable<float> position_d_ch1(
-    position_pid_params_ch1.d, "/ch1/position/d",
-    "D Gain for Channel 1 position controller");
-
-ESPWifiConfig::Configurable<float> position_lpf_ch1(
-    position_pid_params_ch1.lpf_time_constant, "/ch1/position/lpf",
-    "Low pass filter time constant for Channel 1 position controller");
-
-bool save_pid_params_ch0()
+void enable_motors_callback(bool value)
 {
-  motor_ch0.save_position_controller();
-  motor_ch0.save_velocity_controller();
-  motor_ch0.save_torque_controller();
-
-  return true;
-}
-
-bool save_pid_params_ch1()
-{
-  motor_ch1.save_position_controller();
-  motor_ch1.save_velocity_controller();
-  motor_ch1.save_torque_controller();
-
-  return true;
-}
-
-bool load_pid_params_ch0()
-{
-  motor_ch0.load_position_controller();
-  motor_ch0.load_velocity_controller();
-  motor_ch0.load_torque_controller();
-
-  return true;
-}
-
-bool load_pid_params_ch1()
-{
-  motor_ch1.load_position_controller();
-  motor_ch1.load_velocity_controller();
-  motor_ch1.load_torque_controller();
-
-  return true;
-}
-
-// ESPWifiConfig::Readable<bool> call_save_pid_params_ch0(
-//     save_pid_params_ch0, "/ch0/save_pid_params",
-//     "Save PID parameters for Channel 0");
-
-// ESPWifiConfig::Readable<bool> call_save_pid_params_ch1(
-//     save_pid_params_ch1, "/ch1/save_pid_params",
-//     "Save PID parameters for Channel 1");
-
-// ESPWifiConfig::Readable<bool> call_load_pid_params_ch0(
-//     load_pid_params_ch0, "/ch0/load_pid_params",
-//     "Save PID parameters for Channel 0");
-
-// ESPWifiConfig::Readable<bool> call_load_pid_params_ch1(
-//     load_pid_params_ch1, "/ch1/load_pid_params",
-//     "Save PID parameters for Channel 1");
-
-void get_pid_params_ch0()
-{
-  position_pid_params_ch0 = motor_ch0.get_position_controller();
-  velocity_pid_params_ch0 = motor_ch0.get_velocity_controller();
-  current_pid_params_ch0 = motor_ch0.get_torque_controller();
-}
-
-void get_pid_params_ch1()
-{
-  position_pid_params_ch1 = motor_ch1.get_position_controller();
-  velocity_pid_params_ch1 = motor_ch1.get_velocity_controller();
-  current_pid_params_ch1 = motor_ch1.get_torque_controller();
-}
-
-void position_pid_update_ch0(float value)
-{
-  motor_ch0.disable();
-  motor_ch0.set_position_controller(position_pid_params_ch0);
-
-  //   Reset position, velocity, and torque controllers;
-  motor_ch0.reset_position_controller();
-  motor_ch0.reset_velocity_controller();
-  motor_ch0.reset_torque_controller();
-}
-
-void position_pid_update_ch1(float value)
-{
-  motor_ch1.disable();
-  motor_ch1.set_position_controller(position_pid_params_ch1);
-
-  //   Reset position, velocity, and torque controllers;
-  motor_ch1.reset_position_controller();
-  motor_ch1.reset_velocity_controller();
-  motor_ch1.reset_torque_controller();
-}
-
-void velocity_pid_update_ch0(float value)
-{
-  motor_ch0.disable();
-  motor_ch0.set_velocity_controller(velocity_pid_params_ch0);
-
-  //   Reset velocity and torque controllers;
-  motor_ch0.reset_velocity_controller();
-  motor_ch0.reset_torque_controller();
-}
-
-void velocity_pid_update_ch1(float value)
-{
-  motor_ch1.disable();
-  motor_ch1.set_velocity_controller(velocity_pid_params_ch1);
-
-  //   Reset velocity and torque controllers;
-  motor_ch1.reset_velocity_controller();
-  motor_ch1.reset_torque_controller();
-}
-
-void current_pid_update_ch0(float value)
-{
-  motor_ch0.disable();
-  motor_ch0.set_torque_controller(current_pid_params_ch0);
-
-  //   Reset torque controller;
-  motor_ch0.reset_torque_controller();
-}
-
-void current_pid_update_ch1(float value)
-{
-  motor_ch1.disable();
-  motor_ch1.set_torque_controller(current_pid_params_ch1);
-
-  //   Reset torque controller;
-  motor_ch1.reset_torque_controller();
+  if (value)
+  {
+    Serial.println("Enabling motors");
+    motor_ch0.enable();
+    motor_ch1.enable();
+  }
+  else
+  {
+    Serial.println("Disabling motors");
+    motor_ch0.disable();
+    motor_ch1.disable();
+  }
 }
 
 // Function to print at a maximum frequency
@@ -262,63 +67,6 @@ void setup()
   Serial.begin(115200);
   delay(3000);
 
-  //   Configure PID update callbacks
-  current_p_ch0.set_get_callback(get_pid_params_ch0);
-  current_i_ch0.set_get_callback(get_pid_params_ch0);
-  current_d_ch0.set_get_callback(get_pid_params_ch0);
-  current_lpf_ch0.set_get_callback(get_pid_params_ch0);
-
-  current_p_ch1.set_get_callback(get_pid_params_ch1);
-  current_i_ch1.set_get_callback(get_pid_params_ch1);
-  current_d_ch1.set_get_callback(get_pid_params_ch1);
-  current_lpf_ch1.set_get_callback(get_pid_params_ch1);
-
-  velocity_p_ch0.set_get_callback(get_pid_params_ch0);
-  velocity_i_ch0.set_get_callback(get_pid_params_ch0);
-  velocity_d_ch0.set_get_callback(get_pid_params_ch0);
-  velocity_lpf_ch0.set_get_callback(get_pid_params_ch0);
-
-  velocity_p_ch1.set_get_callback(get_pid_params_ch1);
-  velocity_i_ch1.set_get_callback(get_pid_params_ch1);
-  velocity_d_ch1.set_get_callback(get_pid_params_ch1);
-  velocity_lpf_ch1.set_get_callback(get_pid_params_ch1);
-
-  position_p_ch0.set_get_callback(get_pid_params_ch0);
-  position_i_ch0.set_get_callback(get_pid_params_ch0);
-  position_d_ch0.set_get_callback(get_pid_params_ch0);
-  position_lpf_ch0.set_get_callback(get_pid_params_ch0);
-
-  position_p_ch1.set_get_callback(get_pid_params_ch1);
-  position_i_ch1.set_get_callback(get_pid_params_ch1);
-  position_d_ch1.set_get_callback(get_pid_params_ch1);
-
-  current_p_ch0.set_post_callback(current_pid_update_ch0);
-  current_i_ch0.set_post_callback(current_pid_update_ch0);
-  current_d_ch0.set_post_callback(current_pid_update_ch0);
-  current_lpf_ch0.set_post_callback(current_pid_update_ch0);
-
-  current_p_ch1.set_post_callback(current_pid_update_ch1);
-  current_i_ch1.set_post_callback(current_pid_update_ch1);
-  current_d_ch1.set_post_callback(current_pid_update_ch1);
-  current_lpf_ch1.set_post_callback(current_pid_update_ch1);
-
-  velocity_p_ch0.set_post_callback(velocity_pid_update_ch0);
-  velocity_i_ch0.set_post_callback(velocity_pid_update_ch0);
-  velocity_d_ch0.set_post_callback(velocity_pid_update_ch0);
-  velocity_lpf_ch0.set_post_callback(velocity_pid_update_ch0);
-
-  velocity_p_ch1.set_post_callback(velocity_pid_update_ch1);
-  velocity_i_ch1.set_post_callback(velocity_pid_update_ch1);
-  velocity_d_ch1.set_post_callback(velocity_pid_update_ch1);
-  velocity_lpf_ch1.set_post_callback(velocity_pid_update_ch1);
-
-  position_p_ch0.set_post_callback(position_pid_update_ch0);
-  position_i_ch0.set_post_callback(position_pid_update_ch0);
-  position_d_ch0.set_post_callback(position_pid_update_ch0);
-  position_lpf_ch0.set_post_callback(position_pid_update_ch0);
-
-  ESPWifiConfig::WebServer::getInstance().start();
-
   // Setup motor parameters
   motor_params_ch0.pole_pairs = 7;
   motor_params_ch0.power_supply_voltage = 5.0;
@@ -333,6 +81,32 @@ void setup()
   motor_params_ch1.current_limit = 300;
   motor_params_ch1.velocity_limit = 100.0;
   motor_params_ch1.calibration_voltage = 2.0;
+
+  pid_manager.add_controller(
+      "/ch0/torque", current_pid_params_ch0,
+      []() { motor_ch0.set_torque_controller(current_pid_params_ch0); });
+
+  pid_manager.add_controller(
+      "/ch1/torque", current_pid_params_ch1,
+      []() { motor_ch1.set_torque_controller(current_pid_params_ch1); });
+
+  pid_manager.add_controller(
+      "/ch0/velocity", velocity_pid_params_ch0,
+      []() { motor_ch0.set_velocity_controller(velocity_pid_params_ch0); });
+
+  pid_manager.add_controller(
+      "/ch1/velocity", velocity_pid_params_ch1,
+      []() { motor_ch1.set_velocity_controller(velocity_pid_params_ch1); });
+
+  pid_manager.add_controller(
+      "/ch0/position", position_pid_params_ch0,
+      []() { motor_ch0.set_position_controller(position_pid_params_ch0); });
+
+  pid_manager.add_controller(
+      "/ch1/position", position_pid_params_ch1,
+      []() { motor_ch1.set_position_controller(position_pid_params_ch1); });
+
+  enable_motors.set_post_callback(enable_motors_callback);
 
   // Setup Ch0 with FOCStudio enabled
   bool calibrate = false;
@@ -359,12 +133,6 @@ void setup()
   //   Set closed-loop velocity mode
   motor_ch0.set_control_mode(MotorGo::ControlMode::Velocity);
   motor_ch1.set_control_mode(MotorGo::ControlMode::Velocity);
-
-  //   Print url: http://{IP_ADDRESS}:PORT
-  Serial.print("Please connect to http://");
-  Serial.print(WiFi.localIP());
-  Serial.print(":");
-  Serial.println(8080);
 
   //   motorgo_mini->enable_ch0();
   //   motorgo_mini->enable_ch1();

--- a/library.json
+++ b/library.json
@@ -33,7 +33,7 @@
         },
         {
             "name": "ESPWifiConfig",
-            "version": "https://github.com/Every-Flavor-Robotics/esp-wifi-config.git#bug-4/wifi-begin-str"
+            "version": "https://github.com/Every-Flavor-Robotics/esp-wifi-config.git#0.1"
         },
         {
             "name": "Wire",

--- a/library.json
+++ b/library.json
@@ -33,7 +33,7 @@
         },
         {
             "name": "ESPWifiConfig",
-            "version": "https://github.com/Every-Flavor-Robotics/esp-wifi-config.git#feature/configurable-manager"
+            "version": "https://github.com/Every-Flavor-Robotics/esp-wifi-config.git#bug-4/wifi-begin-str"
         },
         {
             "name": "Wire",


### PR DESCRIPTION
Balance bot building was failing because MPU6050 driver was not being built when the sensorgo library was being imported. Moved the driver files to include and src dirs and pinned the version sensorgo driver version for the balance bot example code.

Closes #59.