### PR TITLE
Remove forced calibration if no calibration data available

### DIFF
--- a/include/motorgo_channel.h
+++ b/include/motorgo_channel.h
@@ -118,6 +118,7 @@ class MotorChannel
   // found, the motor will be calibrated anyway and the calibration will be
   // saved to EEPROM
   bool should_calibrate;
+  bool calibration_loaded = false;
 
   // Store whether the parameters have been set
   // If not, the motor will not run be disabled when a command is received

--- a/include/motorgo_common.h
+++ b/include/motorgo_common.h
@@ -43,7 +43,7 @@ struct MotorParameters
 {
   int pole_pairs;
   float power_supply_voltage;
-  float voltage_limit;
+  float voltage_limit = 1000.0f;
   float current_limit = 1000.0f;
   float velocity_limit = 1000.0f;
   float calibration_voltage;

--- a/src/motorgo_channel.cpp
+++ b/src/motorgo_channel.cpp
@@ -66,9 +66,11 @@ void MotorGo::MotorChannel::init(MotorParameters params, bool should_calibrate)
   {
     // If no data was found, issue a warning that only open-loop control will
     // be available
-    Serial.println(
-        "No calibration data found... Motor will only be usable in "
-        "open-loop control modes");
+    // Include name of motor
+    Serial.print("WARNING: No calibration data found for ");
+    Serial.print(name);
+    Serial.println("... Motor will only be usable in open-loop control modes");
+    Serial.println("Set should_calibrate to true to calibrate the motor.")
   }
 
   // Link the calibrated sensor to the motor

--- a/src/motorgo_channel.cpp
+++ b/src/motorgo_channel.cpp
@@ -55,7 +55,7 @@ void MotorGo::MotorChannel::init(MotorParameters params, bool should_calibrate)
   // Initialize motor
   motor.init();
 
-  // Calibrate encoders
+  // Calibrate encoders/motors if flag is set
   sensor_calibrated.voltage_calibration = params.calibration_voltage;
   if (should_calibrate)
   {
@@ -64,8 +64,11 @@ void MotorGo::MotorChannel::init(MotorParameters params, bool should_calibrate)
   // Use calibration data if it exists
   else if (!sensor_calibrated.loadCalibrationData(motor, name))
   {
-    // If no data was found, calibrate the sensor
-    sensor_calibrated.calibrate(motor, name);
+    // If no data was found, issue a warning that only open-loop control will
+    // be available
+    Serial.println(
+        "No calibration data found... Motor will only be usable in "
+        "open-loop control modes");
   }
 
   // Link the calibrated sensor to the motor

--- a/src/motorgo_channel.cpp
+++ b/src/motorgo_channel.cpp
@@ -60,17 +60,23 @@ void MotorGo::MotorChannel::init(MotorParameters params, bool should_calibrate)
   if (should_calibrate)
   {
     sensor_calibrated.calibrate(motor, name);
+    calibration_loaded = true;
   }
   // Use calibration data if it exists
-  else if (!sensor_calibrated.loadCalibrationData(motor, name))
+  else if (sensor_calibrated.loadCalibrationData(motor, name))
+  {
+    // Set flag to indicate that calibration data was loaded
+    calibration_loaded = true;
+  }
+  else
   {
     // If no data was found, issue a warning that only open-loop control will
     // be available
-    // Include name of motor
     Serial.print("WARNING: No calibration data found for ");
     Serial.print(name);
     Serial.println("... Motor will only be usable in open-loop control modes");
-    Serial.println("Set should_calibrate to true to calibrate the motor.")
+    Serial.println("Set should_calibrate to true to calibrate the motor.");
+    calibration_loaded = false;
   }
 
   // Link the calibrated sensor to the motor
@@ -265,7 +271,9 @@ void MotorGo::MotorChannel::set_torque_controller(MotorGo::PIDParameters params)
   motor.PID_current_q.limit = params.limit;
   motor.LPF_current_q.Tf = params.lpf_time_constant;
 
-  pid_torque_enabled = true;
+  //   If calibration data is loaded, enable the torque controller
+  //   Else, keep the torque controller disabled
+  pid_torque_enabled = calibration_loaded;
 }
 
 void MotorGo::MotorChannel::set_velocity_controller(
@@ -278,7 +286,9 @@ void MotorGo::MotorChannel::set_velocity_controller(
   motor.PID_velocity.limit = params.limit;
   motor.LPF_velocity.Tf = params.lpf_time_constant;
 
-  pid_velocity_enabled = true;
+  //   If calibration data is loaded, enable the velocity controller
+  //   Else, keep the velocity controller disabled
+  pid_velocity_enabled = calibration_loaded;
 }
 
 void MotorGo::MotorChannel::set_position_controller(
@@ -291,7 +301,9 @@ void MotorGo::MotorChannel::set_position_controller(
   motor.P_angle.limit = params.limit;
   motor.LPF_angle.Tf = params.lpf_time_constant;
 
-  pid_position_enabled = true;
+  //   If calibration data is loaded, enable the position controller
+  //   Else, keep the position controller disabled
+  pid_position_enabled = calibration_loaded;
 }
 
 void MotorGo::MotorChannel::reset_torque_controller()


### PR DESCRIPTION
Closes #19 

Removes the forced calibration if the user sets `should_calibrate` to false and no calibration is stored in flash. If no calibration is loaded, users are issued a warning and all closed-loop control modes are disabled.

This should mostly help internal dev - removing the requirement to run a calibration to test the boards.