### PR TITLE
Update pin naming convention to match board definition release 1.0

### DIFF
--- a/.github/workflows/test_example_builds.yml
+++ b/.github/workflows/test_example_builds.yml
@@ -27,16 +27,15 @@ jobs:
           pio pkg install --global --tool "platformio/framework-arduinoespressif32"
       - name: Make update_driver_version executable
         run: chmod +x .github/scripts/update_platformio_deps.py
-      - name: Checkout motorgo-arduino repository
+      - name: Checkout motorgo-board-definitions repository
         uses: actions/checkout@v2
         with:
-          repository: "Every-Flavor-Robotics/motorgo-arduino"
+          repository: "Every-Flavor-Robotics/motorgo-board-definitions"
           ref: "main"
-          path: "motorgo-arduino"
+          path: "motorgo-board-definitions"
       - name: Run setup_platformio.py script
         run: |
-          cd motorgo-arduino/board_definitions
-          ls ~/.platformio/packages/
+          cd motorgo-board-definitions/
           python setup_platformio.py
 
       - name: Build Examples

--- a/examples/balance_bot/platformio.ini
+++ b/examples/balance_bot/platformio.ini
@@ -11,7 +11,7 @@
 
 [env:balance_bot]
 platform = platformio/espressif32@^6.1.0
-board = motorgo-mini-v1.2
+board = motorgo_mini_1
 framework = arduino
 monitor_speed = 115200
 lib_deps =

--- a/examples/calibrate_motors/platformio.ini
+++ b/examples/calibrate_motors/platformio.ini
@@ -11,7 +11,7 @@
 
 [env:calibrate_motors]
 platform = platformio/espressif32@^6.1.0
-board = motorgo-mini-v1.2
+board = motorgo_mini_1
 framework = arduino
 monitor_speed = 115200
 lib_deps =

--- a/examples/read_encoders/platformio.ini
+++ b/examples/read_encoders/platformio.ini
@@ -11,7 +11,7 @@
 
 [env:read_encoders]
 platform = platformio/espressif32@^6.1.0
-board = motorgo-mini-v1.2
+board = motorgo_mini_1
 framework = arduino
 monitor_speed = 115200
 lib_deps =

--- a/examples/spin_two_motors/platformio.ini
+++ b/examples/spin_two_motors/platformio.ini
@@ -11,7 +11,7 @@
 
 [env:spin_two_motors]
 platform = platformio/espressif32@^6.1.0
-board = motorgo-mini-v1.2
+board = motorgo_mini_1
 framework = arduino
 monitor_speed = 115200
 lib_deps =

--- a/examples/tune_controllers/platformio.ini
+++ b/examples/tune_controllers/platformio.ini
@@ -11,7 +11,7 @@
 
 [env:tune_controllers]
 platform = platformio/espressif32@^6.1.0
-board = motorgo-mini-v1.2
+board = motorgo_mini_1
 framework = arduino
 monitor_speed = 115200
 lib_deps =

--- a/examples/two_way_haptic_knob/platformio.ini
+++ b/examples/two_way_haptic_knob/platformio.ini
@@ -11,7 +11,7 @@
 
 [env:two_way_haptic_knob]
 platform = platformio/espressif32@^6.1.0
-board = motorgo-mini-v1.2
+board = motorgo_mini_1
 framework = arduino
 monitor_speed = 115200
 lib_deps =

--- a/include/motorgo_common.h
+++ b/include/motorgo_common.h
@@ -9,9 +9,6 @@
 namespace MotorGo
 {
 
-// Define NOT_SET as 255
-#define GPIO_NOT_SET 255
-
 struct BLDCChannelParameters
 {
   uint8_t uh;

--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -13,27 +13,27 @@ class MotorGoMini
 {
  private:
   BLDCChannelParameters ch0_params = {
-      .uh = CH0_GPIO_UH,
-      .ul = CH0_GPIO_UL,
-      .vh = CH0_GPIO_VH,
-      .vl = CH0_GPIO_VL,
-      .wh = CH0_GPIO_WH,
-      .wl = CH0_GPIO_WL,
+      .uh = CH0_UH,
+      .ul = CH0_UL,
+      .vh = CH0_VH,
+      .vl = CH0_VL,
+      .wh = CH0_WH,
+      .wl = CH0_WL,
       .current_u = CH0_CURRENT_U,
-      .current_v = GPIO_NOT_SET,
+      .current_v = CH0_CURRENT_V,
       .current_w = CH0_CURRENT_W,
       .enc_cs = CH0_ENC_CS,
   };
 
   BLDCChannelParameters ch1_params = {
-      .uh = CH1_GPIO_UH,
-      .ul = CH1_GPIO_UL,
-      .vh = CH1_GPIO_VH,
-      .vl = CH1_GPIO_VL,
-      .wh = CH1_GPIO_WH,
-      .wl = CH1_GPIO_WL,
+      .uh = CH1_UH,
+      .ul = CH1_UL,
+      .vh = CH1_VH,
+      .vl = CH1_VL,
+      .wh = CH1_WH,
+      .wl = CH1_WL,
       .current_u = CH1_CURRENT_U,
-      .current_v = GPIO_NOT_SET,
+      .current_v = CH1_CURRENT_V,
       .current_w = CH1_CURRENT_W,
       .enc_cs = CH1_ENC_CS,
   };

--- a/src/motorgo_channel.cpp
+++ b/src/motorgo_channel.cpp
@@ -12,15 +12,15 @@ MotorGo::MotorChannel::MotorChannel(BLDCChannelParameters params,
 {
   // Set current sensing pins to input
   //   If params.current_u is not set (255), set the pin mode to INPUT
-  if (params.current_u != GPIO_NOT_SET)
+  if (params.current_u != MOTORGO_GPIO_NOT_SET)
   {
     pinMode(params.current_u, INPUT);
   }
-  if (params.current_v != GPIO_NOT_SET)
+  if (params.current_v != MOTORGO_GPIO_NOT_SET)
   {
     pinMode(params.current_v, INPUT);
   }
-  if (params.current_w != GPIO_NOT_SET)
+  if (params.current_w != MOTORGO_GPIO_NOT_SET)
   {
     pinMode(params.current_w, INPUT);
   }

--- a/src/motorgo_common.cpp
+++ b/src/motorgo_common.cpp
@@ -10,6 +10,6 @@ void MotorGo::init_encoder_spi()
   if (!hspi_initialized)
   {
     hspi_initialized = true;
-    MotorGo::hspi.begin(ENC_SCL, ENC_SDA, 45, -1);
+    MotorGo::hspi.begin(ENC_SCL, ENC_SDA, ENC_MOSI);
   }
 }

--- a/src/pid_manager.cpp
+++ b/src/pid_manager.cpp
@@ -49,7 +49,7 @@ void MotorGo::PIDManager::init(String wifi_ssid, String wifi_password)
       "Description of available PID controllers");
 
   ESPWifiConfig::WebServer::getInstance().start(wifi_ssid, wifi_password,
-                                                LED_NETWORK);
+                                                LED_STATUS);
 
   //   Display URL to access webserver. http://{ip_address}:{port}
   Serial.println("Webserver available at:");


### PR DESCRIPTION
Pin naming convention was updated for the 1.0 release of the board definitions. Update the driver to match these standards.
* CHX_GPIO_YY -> CHX_YY
* GPIO_NOT_SET -> MOTORGO_GPIO_NOT_SET, defined in pins arduino
* LED_NETWORK -> LED_STATUS
* Remove hard-coded MOSI and chip select pins for encoder SSI bus
* Add support for configuring current sense on V channel