### PR TITLE
Patch: API-Doc Errors

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,10 +1,11 @@
 name: Build and Publish Documentation (Pushes)
 
 on:
-  push:
+  pull_request:
     branches:
-      - main
       - dev
+      - main
+    types: [closed]
 
 jobs:
   build-and-deploy-docs:

--- a/.github/workflows/test_doc_build.yml
+++ b/.github/workflows/test_doc_build.yml
@@ -3,9 +3,8 @@ name: Build Documentation (PR Validation)
 on:
   pull_request:
     branches:
-      - dev
       - main
-    types: [closed]
+      - dev
 
 jobs:
   build-docs:

--- a/.github/workflows/test_doc_build.yml
+++ b/.github/workflows/test_doc_build.yml
@@ -3,8 +3,9 @@ name: Build Documentation (PR Validation)
 on:
   pull_request:
     branches:
-      - main
       - dev
+      - main
+    types: [closed]
 
 jobs:
   build-docs:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,0 @@
-# motorgo-mini-driver
-Driver software for the MotorGo Mini board
-
-## Installation
-MotorGo supports development in PlatformIO and Arduino IDE.
-
-Follow the instructions [here](https://github.com/Every-Flavor-Robotics/motorgo-arduino) to install the MotorGo board definitions and this driver.


### PR DESCRIPTION
* README.md has been replaced by README.rst. Delete as it is no longer necessary.
* Fix building and publishing doc workflow on PR merge.