### PR TITLE
Separate MotorConfiguration and ChannelConfiguration

### DIFF
--- a/examples/balance_bot/src/balance_bot.cpp
+++ b/examples/balance_bot/src/balance_bot.cpp
@@ -136,10 +136,16 @@ void setup()
 
   // Setup motor parameters
   config_left.motor_config = MotorGo::MotorGoGreen;
+  // Configure a lower voltage limit if your MotorGo is restarting
+  // when the motor is loaded.
+  // config_left.motor_config.voltage_limit = 3;
   config_left.power_supply_voltage = 5.0;
   config_left.reversed = false;
 
   config_right.motor_config = MotorGo::MotorGoGreen;
+  // Configure a lower voltage limit if your MotorGo is restarting
+  // when the motor is loaded.
+  // config_right.motor_config.voltage_limit = 3;
   config_right.power_supply_voltage = 5.0;
   config_right.reversed = true;
 

--- a/examples/balance_bot/src/balance_bot.cpp
+++ b/examples/balance_bot/src/balance_bot.cpp
@@ -16,8 +16,8 @@ MotorGo::MotorGoMini motorgo_mini;
 MotorGo::MotorChannel& motor_left = motorgo_mini.ch0;
 MotorGo::MotorChannel& motor_right = motorgo_mini.ch1;
 
-MotorGo::MotorParameters motor_params_left;
-MotorGo::MotorParameters motor_params_right;
+MotorGo::ChannelConfiguration config_left;
+MotorGo::ChannelConfiguration config_right;
 
 // declare PID manager object
 MotorGo::PIDManager pid_manager;
@@ -135,24 +135,18 @@ void setup()
   mpu.calibrate();
 
   // Setup motor parameters
-  motor_params_left.pole_pairs = 7;
-  motor_params_left.power_supply_voltage = 5.0;
-  motor_params_left.voltage_limit = 5.0;
-  motor_params_left.current_limit = 300;
-  motor_params_left.velocity_limit = 100.0;
-  motor_params_left.calibration_voltage = 2.0;
+  config_left.motor_config = MotorGo::MotorGoGreen;
+  config_left.power_supply_voltage = 5.0;
+  config_left.reversed = false;
 
-  motor_params_right.pole_pairs = 7;
-  motor_params_right.power_supply_voltage = 5.0;
-  motor_params_right.voltage_limit = 5.0;
-  motor_params_right.current_limit = 300;
-  motor_params_right.velocity_limit = 100.0;
-  motor_params_right.calibration_voltage = 2.0;
+  config_right.motor_config = MotorGo::MotorGoGreen;
+  config_right.power_supply_voltage = 5.0;
+  config_right.reversed = true;
 
   // Setup both motor channels
   bool calibrate = false;
-  motor_left.init(motor_params_left, calibrate);
-  motor_right.init(motor_params_right, calibrate);
+  motor_left.init(config_left, calibrate);
+  motor_right.init(config_right, calibrate);
 
   // Set motor control mode to voltage control
   motor_left.set_control_mode(MotorGo::ControlMode::Voltage);

--- a/examples/calibrate_motors/src/calibrate_motors.cpp
+++ b/examples/calibrate_motors/src/calibrate_motors.cpp
@@ -6,8 +6,8 @@ MotorGo::MotorGoMini motorgo_mini;
 MotorGo::MotorChannel& motor_ch0 = motorgo_mini.ch0;
 MotorGo::MotorChannel& motor_ch1 = motorgo_mini.ch1;
 
-MotorGo::MotorParameters motor_params_ch0;
-MotorGo::MotorParameters motor_params_ch1;
+MotorGo::ChannelConfiguration config_ch0;
+MotorGo::ChannelConfiguration config_ch1;
 
 // Function to print at a maximum frequency
 void freq_println(String str, int freq)
@@ -27,24 +27,16 @@ void setup()
   Serial.begin(115200);
 
   // Setup motor parameters
-  motor_params_ch0.pole_pairs = 7;
-  motor_params_ch0.power_supply_voltage = 5.0;
-  motor_params_ch0.voltage_limit = 5.0;
-  motor_params_ch0.current_limit = 300;
-  motor_params_ch0.velocity_limit = 100.0;
-  motor_params_ch0.calibration_voltage = 2.0;
+  config_ch0.motor_config = MotorGo::MotorGoGreen;
+  config_ch0.power_supply_voltage = 5.0;
 
-  motor_params_ch1.pole_pairs = 7;
-  motor_params_ch1.power_supply_voltage = 5.0;
-  motor_params_ch1.voltage_limit = 5.0;
-  motor_params_ch1.current_limit = 300;
-  motor_params_ch1.velocity_limit = 100.0;
-  motor_params_ch1.calibration_voltage = 2.0;
+  config_ch1.motor_config = MotorGo::MotorGoGreen;
+  config_ch1.power_supply_voltage = 5.0;
 
   // Setup Ch0
   bool calibrate = true;
-  motor_ch0.init(motor_params_ch0, calibrate);
-  motor_ch1.init(motor_params_ch1, calibrate);
+  motor_ch0.init(config_ch0, calibrate);
+  motor_ch1.init(config_ch1, calibrate);
 }
 
 void loop()

--- a/examples/read_encoders/src/read_encoders.cpp
+++ b/examples/read_encoders/src/read_encoders.cpp
@@ -6,8 +6,8 @@ MotorGo::MotorGoMini motorgo_mini;
 MotorGo::MotorChannel& motor_ch0 = motorgo_mini.ch0;
 MotorGo::MotorChannel& motor_ch1 = motorgo_mini.ch1;
 
-MotorGo::MotorParameters motor_params_ch0;
-MotorGo::MotorParameters motor_params_ch1;
+MotorGo::ChannelConfiguration config_ch0;
+MotorGo::ChannelConfiguration config_ch1;
 
 // Function to print at a maximum frequency
 void freq_println(String str, int freq)
@@ -27,23 +27,15 @@ void setup()
   Serial.begin(115200);
 
   // Setup motor parameters
-  motor_params_ch0.pole_pairs = 7;
-  motor_params_ch0.power_supply_voltage = 5.0;
-  motor_params_ch0.voltage_limit = 5.0;
-  motor_params_ch0.current_limit = 300;
-  motor_params_ch0.velocity_limit = 100.0;
-  motor_params_ch0.calibration_voltage = 2.0;
+  config_ch0.motor_config = MotorGo::MotorGoGreen;
+  config_ch0.power_supply_voltage = 5.0;
 
-  motor_params_ch1.pole_pairs = 7;
-  motor_params_ch1.power_supply_voltage = 5.0;
-  motor_params_ch1.voltage_limit = 5.0;
-  motor_params_ch1.current_limit = 300;
-  motor_params_ch1.velocity_limit = 100.0;
-  motor_params_ch1.calibration_voltage = 2.0;
+  config_ch1.motor_config = MotorGo::MotorGoGreen;
+  config_ch1.power_supply_voltage = 5.0;
 
   // Setup Ch0
-  motor_ch0.init(motor_params_ch0, false);
-  motor_ch1.init(motor_params_ch1, false);
+  motor_ch0.init(config_ch0, false);
+  motor_ch1.init(config_ch1, false);
 }
 
 void loop()

--- a/examples/spin_two_motors/src/spin_two_motors.cpp
+++ b/examples/spin_two_motors/src/spin_two_motors.cpp
@@ -6,8 +6,8 @@ MotorGo::MotorGoMini motorgo_mini;
 MotorGo::MotorChannel& motor_left = motorgo_mini.ch0;
 MotorGo::MotorChannel& motor_right = motorgo_mini.ch1;
 
-MotorGo::MotorParameters motor_params_left;
-MotorGo::MotorParameters motor_params_right;
+MotorGo::ChannelConfiguration config_left;
+MotorGo::ChannelConfiguration config_right;
 
 MotorGo::PIDParameters velocity_pid_params_left;
 MotorGo::PIDParameters velocity_pid_params_right;
@@ -32,36 +32,29 @@ void setup()
   delay(3000);
 
   // Setup motor parameters
-  motor_params_left.pole_pairs = 7;
-  motor_params_left.power_supply_voltage = 5.0;
-  motor_params_left.voltage_limit = 5.0;
-  motor_params_left.current_limit = 300;
-  motor_params_left.velocity_limit = 100.0;
-  motor_params_left.calibration_voltage = 2.0;
-  motor_params_left.reversed = false;
 
-  motor_params_right.pole_pairs = 7;
-  motor_params_right.power_supply_voltage = 5.0;
-  motor_params_right.voltage_limit = 5.0;
-  motor_params_right.current_limit = 300;
-  motor_params_right.velocity_limit = 100.0;
-  motor_params_right.calibration_voltage = 2.0;
-  motor_params_right.reversed = true;
+  config_left.motor_config = MotorGo::MotorGoGreen;
+  config_left.power_supply_voltage = 5.0;
+  config_left.reversed = false;
 
-  // Setup Ch0
+  config_right.motor_config = MotorGo::MotorGoGreen;
+  config_right.power_supply_voltage = 5.0;
+  config_right.reversed = true;
+
+  // Setup
   bool calibrate = false;
-  motor_left.init(motor_params_left, calibrate);
-  motor_right.init(motor_params_right, calibrate);
+  motor_left.init(config_left, calibrate);
+  motor_right.init(config_right, calibrate);
 
   // Set velocity controller parameters
   // Setup PID parameters
-  velocity_pid_params_left.p = 1.6;
+  velocity_pid_params_left.p = 0.8;
   velocity_pid_params_left.i = 0.01;
   velocity_pid_params_left.d = 0.0;
   velocity_pid_params_left.output_ramp = 10000.0;
   velocity_pid_params_left.lpf_time_constant = 0.11;
 
-  velocity_pid_params_right.p = 1.6;
+  velocity_pid_params_right.p = 0.8;
   velocity_pid_params_right.i = 0.01;
   velocity_pid_params_right.d = 0.0;
   velocity_pid_params_right.output_ramp = 10000.0;

--- a/examples/spin_two_motors/src/spin_two_motors.cpp
+++ b/examples/spin_two_motors/src/spin_two_motors.cpp
@@ -67,6 +67,9 @@ void setup()
   motor_left.set_control_mode(MotorGo::ControlMode::Velocity);
   motor_right.set_control_mode(MotorGo::ControlMode::Velocity);
 
+  // Set a velocity limit of 5.0 rad/s for the left motor
+  motor_left.set_velocity_limit(5.0);
+
   //   Enable motors
   motor_left.enable();
   motor_right.enable();
@@ -77,6 +80,7 @@ void loop()
   motor_left.loop();
   motor_right.loop();
 
+  // Left Motor should only spin at 5.0 rad/s, because of the velocity limit
   motor_left.set_target_velocity(10.0);
   motor_right.set_target_velocity(10.0);
 

--- a/examples/tune_controllers/src/tune_controllers.cpp
+++ b/examples/tune_controllers/src/tune_controllers.cpp
@@ -126,8 +126,10 @@ void setup()
   motor_ch0.set_control_mode(MotorGo::ControlMode::Velocity);
   motor_ch1.set_control_mode(MotorGo::ControlMode::Velocity);
 
-  //   motorgo_mini->enable_ch0();
-  //   motorgo_mini->enable_ch1();
+  pid_manager.init(WIFI_SSID, WIFI_PASSWORD);
+
+  //   motor_ch0.enable();
+  //   motor_ch1.enable();
 }
 
 void loop()

--- a/examples/tune_controllers/src/tune_controllers.cpp
+++ b/examples/tune_controllers/src/tune_controllers.cpp
@@ -14,8 +14,8 @@ MotorGo::MotorGoMini motorgo_mini;
 MotorGo::MotorChannel& motor_ch0 = motorgo_mini.ch0;
 MotorGo::MotorChannel& motor_ch1 = motorgo_mini.ch1;
 
-MotorGo::MotorParameters motor_params_ch0;
-MotorGo::MotorParameters motor_params_ch1;
+MotorGo::ChannelConfiguration config_ch0;
+MotorGo::ChannelConfiguration config_ch1;
 
 MotorGo::PIDParameters current_pid_params_ch0;
 MotorGo::PIDParameters current_pid_params_ch1;
@@ -68,19 +68,11 @@ void setup()
   delay(3000);
 
   // Setup motor parameters
-  motor_params_ch0.pole_pairs = 7;
-  motor_params_ch0.power_supply_voltage = 5.0;
-  motor_params_ch0.voltage_limit = 5.0;
-  motor_params_ch0.current_limit = 300;
-  motor_params_ch0.velocity_limit = 100.0;
-  motor_params_ch0.calibration_voltage = 2.0;
+  config_ch0.motor_config = MotorGo::MotorGoGreen;
+  config_ch0.power_supply_voltage = 5.0;
 
-  motor_params_ch1.pole_pairs = 7;
-  motor_params_ch1.power_supply_voltage = 5.0;
-  motor_params_ch1.voltage_limit = 5.0;
-  motor_params_ch1.current_limit = 300;
-  motor_params_ch1.velocity_limit = 100.0;
-  motor_params_ch1.calibration_voltage = 2.0;
+  config_ch1.motor_config = MotorGo::MotorGoGreen;
+  config_ch1.power_supply_voltage = 5.0;
 
   pid_manager.add_controller(
       "/ch0/torque", current_pid_params_ch0,
@@ -110,8 +102,8 @@ void setup()
 
   // Setup Ch0 with FOCStudio enabled
   bool calibrate = false;
-  motor_ch0.init(motor_params_ch0, calibrate);
-  motor_ch1.init(motor_params_ch1, calibrate);
+  motor_ch0.init(config_ch0, calibrate);
+  motor_ch1.init(config_ch1, calibrate);
 
   // Set velocity controller parameters
   // Setup PID parameters

--- a/examples/two_way_haptic_knob/src/two_way_haptic_knob.cpp
+++ b/examples/two_way_haptic_knob/src/two_way_haptic_knob.cpp
@@ -12,8 +12,8 @@ MotorGo::MotorGoMini motorgo_mini;
 MotorGo::MotorChannel& motor_ch0 = motorgo_mini.ch0;
 MotorGo::MotorChannel& motor_ch1 = motorgo_mini.ch1;
 
-MotorGo::MotorParameters motor_params_ch0;
-MotorGo::MotorParameters motor_params_ch1;
+MotorGo::ChannelConfiguration config_ch0;
+MotorGo::ChannelConfiguration config_ch1;
 
 // declare PID manager object
 MotorGo::PIDManager pid_manager;
@@ -64,24 +64,16 @@ void setup()
   delay(3000);
 
   // Setup motor parameters
-  motor_params_ch0.pole_pairs = 7;
-  motor_params_ch0.power_supply_voltage = 5.0;
-  motor_params_ch0.voltage_limit = 5.0;
-  motor_params_ch0.current_limit = 300;
-  motor_params_ch0.velocity_limit = 100.0;
-  motor_params_ch0.calibration_voltage = 2.0;
+  config_ch0.motor_config = MotorGo::MotorGoGreen;
+  config_ch0.power_supply_voltage = 5.0;
 
-  motor_params_ch1.pole_pairs = 7;
-  motor_params_ch1.power_supply_voltage = 5.0;
-  motor_params_ch1.voltage_limit = 5.0;
-  motor_params_ch1.current_limit = 300;
-  motor_params_ch1.velocity_limit = 100.0;
-  motor_params_ch1.calibration_voltage = 2.0;
+  config_ch1.motor_config = MotorGo::MotorGoGreen;
+  config_ch1.power_supply_voltage = 5.0;
 
   // Setup Ch0
   bool calibrate = true;
-  motor_ch0.init(motor_params_ch0, calibrate);
-  motor_ch1.init(motor_params_ch1, calibrate);
+  motor_ch0.init(config_ch0, calibrate);
+  motor_ch1.init(config_ch1, calibrate);
 
   // Instantiate controllers
   motor_ch0.set_velocity_controller(velocity_pid_params_ch0);

--- a/include/motorgo_channel.h
+++ b/include/motorgo_channel.h
@@ -123,6 +123,41 @@ class MotorChannel
   void set_position_controller(PIDParameters params);
 
   /**
+   * @brief Get the user-specified torque limit.
+   *
+   * @return float
+   */
+  float get_torque_limit();
+
+  /**
+   * @brief Get the user-specified velocity limit.
+   *
+   * @return float
+   */
+  float get_velocity_limit();
+
+  /**
+   * @brief Get the user-specified lower position limit.
+   *
+   * @return float
+   */
+  float get_position_limit_low();
+
+  /**
+   * @brief Get the user-specified upper position limit.
+   *
+   * @return float
+   */
+  float get_position_limit_high();
+
+  /**
+   * @brief Get the user-specified voltage limit.
+   *
+   * @return float
+   */
+  float get_voltage_limit();
+
+  /**
    * @brief Sets the maximum torque that can be commanded to the torque
    * controller.
    * @param limit The maximum torque in N*m that can be commanded to the motor.

--- a/include/motorgo_channel.h
+++ b/include/motorgo_channel.h
@@ -48,19 +48,21 @@ class MotorChannel
   /**
   * @brief Initializes motor and encoder with default settings. Calibration
            is automatically loaded.
-  * @param params MotorParameters structure containing motor setup parameters.
+  * @param channel_config ChannelConfiguration structure containing the
+  * configuration for the motor channel.
   */
-  void init(MotorParameters params);
+  void init(ChannelConfiguration channel_config);
 
   /**
    * @brief Initializes motor and encoder with the option of calibration.
    *        If should_calibrate is false, calibration procedure will not run.
    *        Calibration will be loaded from flash if available, else the
    *        channel will only run open loop control modes
-   * @param params MotorParameters structure containing motor setup parameters.
+   * @param channel_config ChannelConfiguration structure containing the
+   * configuration for the motor channel.
    * @param should_calibrate If true, performs calibration on startup.
    */
-  void init(MotorParameters params, bool should_calibrate);
+  void init(ChannelConfiguration channel_config, bool should_calibrate);
 
   /** @} */  // end of motor_initialization group
 
@@ -303,7 +305,7 @@ class MotorChannel
   CalibratedSensor sensor_calibrated;
 
   // Additional motor and encoder parameters
-  MotorParameters motor_params;
+  ChannelConfiguration channel_config;
   Direction motor_direction;
 
   // Current targets
@@ -338,9 +340,9 @@ class MotorChannel
   // MotorGo Limits
   // MotorGo Mini driver voltage limit
   // TODO: Move these to board definitions
-  float voltage_limit = 11.0f;
+  const float DRIVER_VOLTAGE_LIMIT = 11.0f;
   // MotorGo Mini driver current limit
-  float current_limit = 2.5f;
+  const float DRIVER_CURRENT_LIMIT = 2.5f;
 
   // Calibration parameters
   // If should_calibrate is set to true, the motor will be calibrated on startup

--- a/include/motorgo_channel.h
+++ b/include/motorgo_channel.h
@@ -342,7 +342,7 @@ class MotorChannel
   // TODO: Move these to board definitions
   const float DRIVER_VOLTAGE_LIMIT = 11.0f;
   // MotorGo Mini driver current limit
-  const float DRIVER_CURRENT_LIMIT = 2.5f;
+  const float DRIVER_CURRENT_LIMIT = 1.8f;
 
   // Calibration parameters
   // If should_calibrate is set to true, the motor will be calibrated on startup

--- a/include/motorgo_channel.h
+++ b/include/motorgo_channel.h
@@ -374,10 +374,16 @@ class MotorChannel
 
   // MotorGo Limits
   // MotorGo Mini driver voltage limit
-  // TODO: Move these to board definitions
+  // TODO: Some board definitions include the voltage limit, others don't
+  // Set a default for now thats safe for the released hardware
+#ifndef DRIVER_VOLTAGE_LIMIT
   const float DRIVER_VOLTAGE_LIMIT = 11.0f;
+#endif
+
   // MotorGo Mini driver current limit
+#ifndef DRIVER_CURRENT_LIMIT
   const float DRIVER_CURRENT_LIMIT = 1.8f;
+#endif
 
   // Calibration parameters
   // If should_calibrate is set to true, the motor will be calibrated on startup

--- a/include/motorgo_channel.h
+++ b/include/motorgo_channel.h
@@ -53,16 +53,16 @@ class MotorChannel
   void init(MotorParameters params);
 
   /**
-  * @brief Initializes motor and encoder with the option of calibration.
-  *        If should_calibrate is false, calibration procedure will not run.
-  *        Calibration will be loaded from flash if available, else the
-  *        channel will only run open loop control modes
-  * @param params MotorParameters structure containing motor setup parameters.
-  * @param should_calibrate If true, performs calibration on startup.
-  */
+   * @brief Initializes motor and encoder with the option of calibration.
+   *        If should_calibrate is false, calibration procedure will not run.
+   *        Calibration will be loaded from flash if available, else the
+   *        channel will only run open loop control modes
+   * @param params MotorParameters structure containing motor setup parameters.
+   * @param should_calibrate If true, performs calibration on startup.
+   */
   void init(MotorParameters params, bool should_calibrate);
 
-    /** @} */  // end of motor_initialization group
+  /** @} */  // end of motor_initialization group
 
   /**
    * @brief Runs the control loop for the motor channel and updates encoder
@@ -113,7 +113,7 @@ class MotorChannel
    */
   void set_velocity_controller(PIDParameters params);
 
-   /**
+  /**
    * @brief Sets the PID parameters for the position controller.
    * @param params The PIDParameters structure to configure the position
    * controller.
@@ -121,15 +121,47 @@ class MotorChannel
   void set_position_controller(PIDParameters params);
 
   /**
+   * @brief Sets the maximum torque that can be commanded to the torque
+   * controller.
+   * @param limit The maximum torque in N*m that can be commanded to the motor.
+   * @note This limit is only enforced if the motor is in torque control mode.
+   */
+  void set_torque_limit(float limit);
+
+  /**
+   * @brief Sets the maximum velocity that can be commanded to the velocity
+   * controller.
+   * @param limit The maximum velocity in rad/s that can be commanded to the
+   * motor.
+   * @note This limit is only enforced if the motor is in velocity control mode.
+   */
+  void set_velocity_limit(float limit);
+
+  /**
+   * @brief Sets the position limits for the position controller.
+   * @param low The lower position limit in radians.
+   * @param high The upper position limit in radians.
+   * @note This limit is only enforced if the motor is in position control mode.
+   */
+  void set_position_limit(float low, float high);
+
+  /**
+   * @brief Sets the maximum voltage that can be commanded to the motor.
+   * @param limit The maximum voltage in V that can be commanded to the motor.
+   * @note This limit is only enforced if the motor is in voltage control mode.
+   */
+  void set_voltage_limit(float limit);
+
+  /**
    * @brief Resets the internal state of the torque controller. This clears
    *        the integral term and sets the output to zero.
    */
   void reset_torque_controller();
 
-   /**
-    * @brief Resets the internal state of the velocity controller. This clears
-    *        the integral term and sets the output to zero.
-    */
+  /**
+   * @brief Resets the internal state of the velocity controller. This clears
+   *        the integral term and sets the output to zero.
+   */
   void reset_velocity_controller();
 
   /**
@@ -168,7 +200,7 @@ class MotorChannel
    */
   void load_position_controller();
 
-    /** @} */  // end of pid_controller_management group
+  /** @} */  // end of pid_controller_management group
 
   /**
    * @name Motor Command
@@ -258,7 +290,6 @@ class MotorChannel
 
   /** @} */  // end of state_retrieval group
 
-
  private:
   //    Motor name
   //   Used to store calibration parameters in EEPROM
@@ -285,12 +316,31 @@ class MotorChannel
 
   // Rad/s
   float target_velocity = 0.0f;
+  bool velocity_limit_enabled = false;
+  float velocity_limit = 0.0f;
+
   // N*m
   float target_torque = 0.0f;
+  bool torque_limit_enabled = false;
+  float torque_limit = 0.0f;
+
   // Rad
   float target_position = 0.0f;
+  bool position_limit_enabled = false;
+  float position_limit_low = 0.0f;
+  float position_limit_high = 0.0f;
+
   // V
   float target_voltage = 0.0f;
+  bool voltage_limit_enabled = false;
+  float voltage_limit = 10000.0f;
+
+  // MotorGo Limits
+  // MotorGo Mini driver voltage limit
+  // TODO: Move these to board definitions
+  float voltage_limit = 11.0f;
+  // MotorGo Mini driver current limit
+  float current_limit = 2.5f;
 
   // Calibration parameters
   // If should_calibrate is set to true, the motor will be calibrated on startup

--- a/include/motorgo_common.h
+++ b/include/motorgo_common.h
@@ -55,7 +55,7 @@ enum ControlMode
  */
 struct MotorConfiguration
 {
-  int pole_pairs;
+  int pole_pairs = -1;
   float kv = NOT_SET;
   float phase_resistance = NOT_SET;
   float phase_inductance = NOT_SET;

--- a/include/motorgo_common.h
+++ b/include/motorgo_common.h
@@ -45,25 +45,40 @@ enum ControlMode
 };
 
 /**
- * @struct MotorParameters
- * @brief Structure to store parameters for motor configuration.
+ * @struct MotorConfiguration
+ * @brief Structure that stores the motor configuration.
  *
- * Encapsulates various parameters required for setting up a motor, such as the
- * number of pole pairs, power supply voltage, limits on voltage and current,
- * and calibration voltage.
- */struct MotorParameters
+ * These parameters describe the motor's electrical and mechanical properties,
+ * such as the number of pole pairs, the motor's velocity constant (kv), phase
+ * resistance, and phase inductance. The limits characterize the safe
+ * operating range of the motor.
+ */
+struct MotorConfiguration
 {
   int pole_pairs;
   float kv = NOT_SET;
   float phase_resistance = NOT_SET;
   float phase_inductance = NOT_SET;
 
-  float power_supply_voltage;
   float voltage_limit = 1000.0f;
   float current_limit = 1000.0f;
   float velocity_limit = 1000.0f;
-  float calibration_voltage;
-  bool reversed = false;
+  float calibration_voltage = NOT_SET;
+};
+
+/**
+ * @struct ChannelConfiguration
+ * @brief Structure that stores the configuration for setting up a motor
+ * channel. This includes the motor configuration, the power supply voltage,
+ * and whether the motor should be reversed. If reversed is false, the motor
+ * will rotate counter-clockwise with a positive command. If reversed is true,
+ * the motor will rotate clockwise with a positive command.
+ */
+struct ChannelConfiguration
+{
+  MotorConfiguration motor_config;
+  float power_supply_voltage;
+  float reversed;
 };
 
 /**
@@ -72,8 +87,8 @@ enum ControlMode
  *
  * This structure encapsulates the proportional (P), integral (I), and
  * derivative (D) parameters used in PID control, along with additional
- * parameters such as output ramp rate, low pass filter time constant, and limit
- * for the output.
+ * parameters such as output ramp rate, low pass filter time constant, and
+ * limit for the output.
  */
 struct PIDParameters
 {

--- a/include/motorgo_common.h
+++ b/include/motorgo_common.h
@@ -59,11 +59,39 @@ struct MotorConfiguration
   float kv = NOT_SET;
   float phase_resistance = NOT_SET;
   float phase_inductance = NOT_SET;
-
   float voltage_limit = 1000.0f;
   float current_limit = 1000.0f;
   float velocity_limit = 1000.0f;
   float calibration_voltage = NOT_SET;
+
+  // Default constructor
+  MotorConfiguration()
+      : pole_pairs(-1),
+        kv(NOT_SET),
+        phase_resistance(NOT_SET),
+        phase_inductance(NOT_SET),
+        voltage_limit(1000.0f),
+        current_limit(1000.0f),
+        velocity_limit(1000.0f),
+        calibration_voltage(NOT_SET)
+  {
+  }
+
+  // Constructor with parameters
+  MotorConfiguration(int pole_pairs, float kv, float phase_resistance,
+                     float phase_inductance, float voltage_limit,
+                     float current_limit, float velocity_limit,
+                     float calibration_voltage)
+      : pole_pairs(pole_pairs),
+        kv(kv),
+        phase_resistance(phase_resistance),
+        phase_inductance(phase_inductance),
+        voltage_limit(voltage_limit),
+        current_limit(current_limit),
+        velocity_limit(velocity_limit),
+        calibration_voltage(calibration_voltage)
+  {
+  }
 };
 
 /**

--- a/include/motorgo_common.h
+++ b/include/motorgo_common.h
@@ -6,6 +6,8 @@
 #include <Arduino.h>
 #include <SPI.h>
 
+#include "SimpleFOC.h"
+
 namespace MotorGo
 {
 
@@ -52,6 +54,10 @@ enum ControlMode
  */struct MotorParameters
 {
   int pole_pairs;
+  float kv = NOT_SET;
+  float phase_resistance = NOT_SET;
+  float phase_inductance = NOT_SET;
+
   float power_supply_voltage;
   float voltage_limit = 1000.0f;
   float current_limit = 1000.0f;

--- a/include/motorgo_mini.h
+++ b/include/motorgo_mini.h
@@ -3,6 +3,7 @@
 
 #include "motorgo_channel.h"
 #include "motorgo_common.h"
+#include "motorgo_motors.h"
 
 namespace MotorGo
 {
@@ -13,7 +14,8 @@ namespace MotorGo
  *
  * This class sets up and encapsulates the MotorChannel objects for the two
  * motor channels on the MotorGo Mini. The MotorChannel is the primary
- * interface for controlling and managing BLDC motors using the MotorGo hardware.
+ * interface for controlling and managing BLDC motors using the MotorGo
+ * hardware.
  */
 class MotorGoMini
 {

--- a/include/motorgo_motors.h
+++ b/include/motorgo_motors.h
@@ -18,7 +18,7 @@ const MotorConfiguration MotorGoGreen(
     NOT_SET,   //   320.0f,    // kv
     NOT_SET,   //   2.3f,      // phase_resistance
     NOT_SET,   // phase_inductance
-    2.8,       // 12.0f,     // voltage_limit
+    4.15,      // 12.0f,     // voltage_limit
     2.5f,      // current_limit
     10000.0f,  // velocity_limit
     1.0f       // calibration_voltage

--- a/include/motorgo_motors.h
+++ b/include/motorgo_motors.h
@@ -7,6 +7,12 @@
 
 namespace MotorGo
 {
+
+/**
+ * @brief Configuration for the official MotorGo Green motor. This is a
+ * PTZ 2804 motor.
+ *
+ */
 const MotorConfiguration MotorGoGreen(7,         // pole_pairs
                                       320.0f,    // kv
                                       2.3f,      // phase_resistance

--- a/include/motorgo_motors.h
+++ b/include/motorgo_motors.h
@@ -1,0 +1,20 @@
+// Header fill to store configurations for the official MotorGo motors
+
+#ifndef MOTORGO_MOTORS_H
+#define MOTORGO_MOTORS_H
+
+#include "motorgo_common.h"
+
+namespace MotorGo
+{
+const MotorConfiguration MotorGoGreen(7,         // pole_pairs
+                                      320.0f,    // kv
+                                      2.3f,      // phase_resistance
+                                      NOT_SET,   // phase_inductance
+                                      12.0f,     // voltage_limit
+                                      2.5f,      // current_limit
+                                      10000.0f,  // velocity_limit
+                                      1.0f       // calibration_voltage
+);
+}  // namespace MotorGo
+#endif  // MOTORGO_MOTORS_H

--- a/include/motorgo_motors.h
+++ b/include/motorgo_motors.h
@@ -13,14 +13,16 @@ namespace MotorGo
  * PTZ 2804 motor.
  *
  */
-const MotorConfiguration MotorGoGreen(7,         // pole_pairs
-                                      320.0f,    // kv
-                                      2.3f,      // phase_resistance
-                                      NOT_SET,   // phase_inductance
-                                      12.0f,     // voltage_limit
-                                      2.5f,      // current_limit
-                                      10000.0f,  // velocity_limit
-                                      1.0f       // calibration_voltage
+const MotorConfiguration MotorGoGreen(
+    7,         // pole_pairs
+    NOT_SET,   //   320.0f,    // kv
+    NOT_SET,   //   2.3f,      // phase_resistance
+    NOT_SET,   // phase_inductance
+    2.8,       // 12.0f,     // voltage_limit
+    2.5f,      // current_limit
+    10000.0f,  // velocity_limit
+    1.0f       // calibration_voltage
 );
+
 }  // namespace MotorGo
 #endif  // MOTORGO_MOTORS_H

--- a/include/motorgo_motors.h
+++ b/include/motorgo_motors.h
@@ -18,7 +18,7 @@ const MotorConfiguration MotorGoGreen(
     NOT_SET,   //   320.0f,    // kv
     NOT_SET,   //   2.3f,      // phase_resistance
     NOT_SET,   // phase_inductance
-    4.15,      // 12.0f,     // voltage_limit
+    4.10,      // 12.0f,     // voltage_limit
     2.5f,      // current_limit
     10000.0f,  // velocity_limit
     1.0f       // calibration_voltage

--- a/src/motorgo_channel.cpp
+++ b/src/motorgo_channel.cpp
@@ -334,7 +334,7 @@ void MotorGo::MotorChannel::set_torque_controller(MotorGo::PIDParameters params)
   motor.PID_current_q.I = params.i;
   motor.PID_current_q.D = params.d;
   motor.PID_current_q.output_ramp = params.output_ramp;
-  motor.PID_current_q.limit = params.limit;
+  //   motor.PID_current_q.limit = params.limit;
   motor.LPF_current_q.Tf = params.lpf_time_constant;
 
   //   If calibration data is loaded, enable the torque controller
@@ -349,7 +349,7 @@ void MotorGo::MotorChannel::set_velocity_controller(
   motor.PID_velocity.I = params.i;
   motor.PID_velocity.D = params.d;
   motor.PID_velocity.output_ramp = params.output_ramp;
-  motor.PID_velocity.limit = params.limit;
+  //   motor.PID_velocity.limit = params.limit;
   motor.LPF_velocity.Tf = params.lpf_time_constant;
 
   //   If calibration data is loaded, enable the velocity controller
@@ -364,7 +364,7 @@ void MotorGo::MotorChannel::set_position_controller(
   motor.P_angle.I = params.i;
   motor.P_angle.D = params.d;
   motor.P_angle.output_ramp = params.output_ramp;
-  motor.P_angle.limit = params.limit;
+  //   motor.P_angle.limit = params.limit;
   motor.LPF_angle.Tf = params.lpf_time_constant;
 
   //   If calibration data is loaded, enable the position controller
@@ -427,7 +427,7 @@ void MotorGo::MotorChannel::load_controller_helper(const char* key,
   controller.I = packed_params.i;
   controller.D = packed_params.d;
   controller.output_ramp = packed_params.output_ramp;
-  controller.limit = packed_params.limit;
+  //   controller.limit = packed_params.limit;
   lpf.Tf = packed_params.lpf_time_constant;
 }
 

--- a/src/motorgo_channel.cpp
+++ b/src/motorgo_channel.cpp
@@ -294,6 +294,22 @@ void MotorGo::MotorChannel::set_target_voltage(float target)
   }
 }
 
+float MotorGo::MotorChannel::get_torque_limit() { return torque_limit; }
+
+float MotorGo::MotorChannel::get_velocity_limit() { return velocity_limit; }
+
+float MotorGo::MotorChannel::get_position_limit_low()
+{
+  return position_limit_low;
+}
+
+float MotorGo::MotorChannel::get_position_limit_high()
+{
+  return position_limit_high;
+}
+
+float MotorGo::MotorChannel::get_voltage_limit() { return voltage_limit; }
+
 void MotorGo::MotorChannel::set_torque_limit(float limit)
 {
   torque_limit = limit;

--- a/src/motorgo_channel.cpp
+++ b/src/motorgo_channel.cpp
@@ -37,6 +37,9 @@ void MotorGo::MotorChannel::init(MotorParameters params, bool should_calibrate)
   motor.KV_rating = params.kv;
   motor.phase_resistance = params.phase_resistance;
   motor.phase_inductance = params.phase_inductance;
+  //   Set default LPF time constants
+  motor.LPF_velocity.Tf = 0.001;
+  motor.LPF_angle.Tf = 0.001;
 
   // Init encoder
   encoder.init(&MotorGo::hspi);

--- a/src/motorgo_channel.cpp
+++ b/src/motorgo_channel.cpp
@@ -285,18 +285,18 @@ void MotorGo::MotorChannel::set_target_voltage(float target)
 
   if (voltage_limit_enabled)
   {
-    // With the phase resistance and KV set, voltage control behaves
-    // Similarly to an estimated current control. However, SimpleFOC does not
-    // account for the current limits set in this mode. Since we use the current
-    // limit as a way to protect the motor, we use the lesser of the voltage
-    // limit and the current limit as the limit for the voltage control.
-    float limit = min(voltage_limit, channel_config.motor_config.current_limit);
-    target_voltage = _constrain(target_voltage, -limit, limit);
+    target_voltage = _constrain(target_voltage, -voltage_limit, voltage_limit);
   }
 
   if (control_mode == MotorGo::ControlMode::Voltage)
   {
-    motor.move(target_voltage);
+    // With the phase resistance and KV set, voltage control behaves
+    // similarly to an estimated current control. However, SimpleFOC does not
+    // account for the current limits set in this mode. Since we use the current
+    // limit as a way to protect the motor, we also constrain the voltage
+    // command to the current limit.
+    motor.move(
+        _constrain(target_voltage, -motor.current_limit, motor.current_limit));
   }
 }
 

--- a/src/motorgo_channel.cpp
+++ b/src/motorgo_channel.cpp
@@ -285,7 +285,13 @@ void MotorGo::MotorChannel::set_target_voltage(float target)
 
   if (voltage_limit_enabled)
   {
-    target_voltage = _constrain(target_voltage, -voltage_limit, voltage_limit);
+    // With the phase resistance and KV set, voltage control behaves
+    // Similarly to an estimated current control. However, SimpleFOC does not
+    // account for the current limits set in this mode. Since we use the current
+    // limit as a way to protect the motor, we use the lesser of the voltage
+    // limit and the current limit as the limit for the voltage control.
+    float limit = min(voltage_limit, channel_config.motor_config.current_limit);
+    target_voltage = _constrain(target_voltage, -limit, limit);
   }
 
   if (control_mode == MotorGo::ControlMode::Voltage)

--- a/src/motorgo_channel.cpp
+++ b/src/motorgo_channel.cpp
@@ -34,6 +34,9 @@ void MotorGo::MotorChannel::init(MotorParameters params, bool should_calibrate)
 
   // Set the correct number of pole pairs
   motor.pole_pairs = params.pole_pairs;
+  motor.KV_rating = params.kv;
+  motor.phase_resistance = params.phase_resistance;
+  motor.phase_inductance = params.phase_inductance;
 
   // Init encoder
   encoder.init(&MotorGo::hspi);

--- a/src/motorgo_channel.cpp
+++ b/src/motorgo_channel.cpp
@@ -190,6 +190,12 @@ void MotorGo::MotorChannel::set_target_velocity(float target)
 {
   target_velocity = target * motor_direction;
 
+  if (velocity_limit_enabled)
+  {
+    target_velocity =
+        _constrain(target_velocity, -velocity_limit, velocity_limit);
+  }
+
   // If the control mode is velocity open loop, move the motor
   // If closed loop velocity, move the motor only if PID params are set
   switch (control_mode)
@@ -212,6 +218,10 @@ void MotorGo::MotorChannel::set_target_velocity(float target)
 void MotorGo::MotorChannel::set_target_torque(float target)
 {
   target_torque = target * motor_direction;
+  if (torque_limit_enabled)
+  {
+    target_torque = _constrain(target_torque, -torque_limit, torque_limit);
+  }
 
   if (control_mode == MotorGo::ControlMode::Torque)
   {
@@ -229,6 +239,12 @@ void MotorGo::MotorChannel::set_target_torque(float target)
 void MotorGo::MotorChannel::set_target_position(float target)
 {
   target_position = target * motor_direction;
+
+  if (position_limit_enabled)
+  {
+    target_position =
+        _constrain(target_position, position_limit_low, position_limit_high);
+  }
 
   // If the control mode is position open loop, move the motor
   // If closed loop position, move the motor only if PID params are set
@@ -253,7 +269,41 @@ void MotorGo::MotorChannel::set_target_position(float target)
 void MotorGo::MotorChannel::set_target_voltage(float target)
 {
   target_voltage = target * motor_direction;
-  motor.move(target_voltage);
+
+  if (voltage_limit_enabled)
+  {
+    target_voltage = _constrain(target_voltage, -voltage_limit, voltage_limit);
+  }
+
+  if (control_mode == MotorGo::ControlMode::Voltage)
+  {
+    motor.move(target_voltage);
+  }
+}
+
+void MotorGo::MotorChannel::set_torque_limit(float limit)
+{
+  torque_limit = limit;
+  torque_limit_enabled = true;
+}
+
+void MotorGo::MotorChannel::set_velocity_limit(float limit)
+{
+  velocity_limit = limit;
+  velocity_limit_enabled = true;
+}
+
+void MotorGo::MotorChannel::set_position_limit(float low, float high)
+{
+  position_limit_low = low;
+  position_limit_high = high;
+  position_limit_enabled = true;
+}
+
+void MotorGo::MotorChannel::set_voltage_limit(float limit)
+{
+  voltage_limit = limit;
+  voltage_limit_enabled = true;
 }
 
 void MotorGo::MotorChannel::zero_position()

--- a/src/motorgo_channel.cpp
+++ b/src/motorgo_channel.cpp
@@ -295,8 +295,11 @@ void MotorGo::MotorChannel::set_target_voltage(float target)
     // account for the current limits set in this mode. Since we use the current
     // limit as a way to protect the motor, we also constrain the voltage
     // command to the current limit.
-    motor.move(
-        _constrain(target_voltage, -motor.current_limit, motor.current_limit));
+    // motor.move(
+    //     _constrain(target_voltage, -motor.current_limit,
+    //     motor.current_limit));
+
+    motor.move(target_voltage);
   }
 }
 


### PR DESCRIPTION
* Separated MotorParameters into MotorConfiguration and ChannelConfiguration. MotorConfiguration describes physical specs of motors, and ChannelConfiguration describes the specs of the motor driver. 
* Created a default MotorGoGreen motor for the PTZ 2804 motors, with limits to protect from thermal protection limits.
* Removed ability to set limits for the cascaded PID controller built-in to SimpleFOC, as these are used to handle the current and voltage limits of the driver and motor
* Added getters and setters for user-configurable limits on torque, velocity, position, and voltage.

Closes #70 
Closes #78 