### PR TITLE
Changed output dir for packaged arduino library

### DIFF
--- a/.github/workflows/package_arduino_lib.yml
+++ b/.github/workflows/package_arduino_lib.yml
@@ -32,7 +32,7 @@ jobs:
           REPO_NAME: ${{ github.repository }} # Set environment variable
         run: |
           python .github/scripts/package_arduino_lib.py library.json motorgo-mini-driver \
-            --output-dir $GITHUB_WORKSPACE/motorgo-arduino/arduino_library \
+            --output-dir $GITHUB_WORKSPACE/motorgo-arduino/ \
             --storage-dir ./tmp
 
       # Open Pull Request


### PR DESCRIPTION
motorgo-arduino only contains the arduino library now, github workflow is updated to reflect that change. 
Closes #73 