### PR TITLE
Fix zero_position incorrectly setting zero

### DIFF
--- a/src/motorgo_channel.cpp
+++ b/src/motorgo_channel.cpp
@@ -258,7 +258,10 @@ void MotorGo::MotorChannel::set_target_voltage(float target)
 
 void MotorGo::MotorChannel::zero_position()
 {
-  motor.sensor_offset = motor.shaftAngle();
+  // Shaft angle returns the filtered angle, with the sensor offset applied
+  //   Add current sensor_offset back to the current shaft angle to
+  //   recover the filtered (but not offset) angle
+  motor.sensor_offset = motor.shaftAngle() + motor.sensor_offset;
 }
 
 // Built In PID controller functions


### PR DESCRIPTION
position_zero() function was incorrectly setting the sensor offset as it was using the previous sensor_offset in the computation. Function has been updated to remove sensor_offset from computation.

Closes #79 