### PR TITLE
Docs 87/improve getting started

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 MotorGo Mini Driver
 ==================
 
-The 'MotorGo Mini <https://motorgo.net>'_ is a 2-channel brushless motor controller and microcontroller combo designed to accelerate the process of robot prototype development. MotorGo Mini handles the low-level details of motor control, including power distribution, current sensing, encoder reading, PID controls, and communications, so that you can focus on the high-level details of your robot's behavior.
+The `MotorGo Mini <https://motorgo.net>`_ is a 2-channel brushless motor controller and microcontroller combo designed to accelerate the process of robot prototype development. MotorGo Mini handles the low-level details of motor control, including power distribution, current sensing, encoder reading, PID controls, and communications, so that you can focus on the high-level details of your robot's behavior.
 
 Key Hardware Features:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'MotorGo Mini Driver'
+project = 'MotorGo Docs'
 copyright = '2023, Every Flavor Robotics LLC, MotorGo LLC'
 author = 'Every Flavor Robotics LLC, MotorGo LLC'
 
@@ -21,17 +21,17 @@ extensions = [
 ]
 
 breathe_projects = {
-    'MotorGo Mini Driver': './doxyoutput/xml',  # Point to your Doxygen XML output directory
+    'MotorGo Docs': './doxyoutput/xml',  # Point to your Doxygen XML output directory
 }
 
-breathe_default_project = 'MotorGo Mini Driver'
+breathe_default_project = 'MotorGo Docs'
 
 # Setup the exhale extension
 exhale_args = {
     # These arguments are required
     "containmentFolder":     "./api",
     "rootFileName":          "api_reference.rst",
-    "afterTitleDescription": "MotorGo Mini Driver API",
+    "afterTitleDescription": "Docs for the MotorGo Product Line",
     "doxygenStripFromPath":  "..",
     # Heavily encouraged optional argument (see docs)
     "rootFileTitle":         "API Reference",

--- a/docs/getting_started/calibration.rst
+++ b/docs/getting_started/calibration.rst
@@ -19,7 +19,9 @@ The calibration step also automatically determines the direction of the motor. A
 
 **Calibration Sketch**
 
-This sketch will run the calibration routine for channel 0 on the MotorGo. If you want to calibrate channel 1, simply change the function calls to ``init_ch1`` and ``loop_ch1``.
+You can open this sketch from the MotorGo Mini Driver examples in the Arduino IDE or by `downloading this project <https://github.com/Every-Flavor-Robotics/motorgo-mini-driver/tree/main/examples/calibrate_motors>`_ for PlatformIO.
+
+This sketch will run the calibration routine for channel 0 and channel 1 on the MotorGo.
 
 - The calibration sweep involves a slow, 360-degree rotation of the rotor in both directions.
 - This process maps the rotor's position to the encoder's readings.
@@ -79,6 +81,18 @@ This sketch will run the calibration routine for channel 0 on the MotorGo. If yo
 
         freq_println(str, 10);
     }
+
+If you are using PlatformIO, you can configure the project with the following platformio.ini file.
+
+.. code-block:: ini
+
+    [env:calibrate_motors]
+    platform = platformio/espressif32@^6.1.0
+    board = motorgo_mini_1
+    framework = arduino
+    monitor_speed = 115200
+    lib_deps =
+        https://github.com/Every-Flavor-Robotics/motorgo-mini-driver.git#v1.0.0
 
 
 Let's break the code down line by line. You can segment all code for the MotorGo into three parts:

--- a/docs/getting_started/software_setup.rst
+++ b/docs/getting_started/software_setup.rst
@@ -27,7 +27,7 @@ First, install the ESP32 board definitions, if you have not already done so.
 * Search for `Espressif 32`
 * Click `Install`
 
-Next, you'll have to install the MotorGo board definition, which is available in this respository.
+Next, you'll have to install the MotorGo board definition, which is available in the `MotorGo Board Definitions repository <https://github.com/Every-Flavor-Robotics/motorgo-board-definitions>`_.
 
 **Arduino IDE 1.X/2.X**
 
@@ -36,6 +36,7 @@ Next, you'll have to install the MotorGo board definition, which is available in
 * Go to `Tools > Board > Boards Manager...`
 * Search for `MotorGo`
 * Click `Install`
+* Select
 
 **PlatformIO**
 
@@ -43,26 +44,45 @@ Next, you'll have to install the MotorGo board definition, which is available in
 * Navigate to the root of the this repository
 * Run the python script `python3 setup_platformio.py`
 
+Or you can paste the following commands into your terminal.
+
+.. code-block:: bash
+
+  git clone https://github.com/Every-Flavor-Robotics/motorgo-board-definitions.git
+  cd motorgo-board-definitions
+  python3 setup_platformio.py    
+
+To use the board definition, either select the MotorGo Mini 1 from the list of boards when creating a new project OR modify the board in your `platformio.ini` file as follows:
+
+.. code-block:: ini
+
+  board = motorgo_mini_1
+
+
+
 
 If you're in Arduino IDE, you should be able to now select the MotorGo Mini 1 from the board list. If you're in PlatformIO, you should be able to select the MotorGo Mini 1 from the board list OR modify the `board` in `platformio.ini` to `motorgo_mini_1`. To test this is working as expected, you can upload the `Blink` example to the MotorGo Mini 1 board. If the onboard LED blinks, you're good to go!
 
 Setting up the MotorGo Mini driver library
 ------------------------------------------
 
-The MotorGo Mini library provides an easy interface to control motors and read encoders using the onboard hardware. The main code for the library is available `here <https://github.com/Every-Flavor-Robotics/motorgo-mini-driver>`. The Arduino compatible library is available `here <https://github.com/Every-Flavor-Robotics/motorgo-arduino>`. Below are instructions for setting the library up.
+The MotorGo Mini library provides an easy interface to control motors and read encoders using the onboard hardware. The main code for the library (PlatformIO package) is available `here <https://github.com/Every-Flavor-Robotics/motorgo-mini-driver>`_. The Arduino compatible library is available `here <https://github.com/Every-Flavor-Robotics/motorgo-arduino>`_. Below are instructions for setting the library up.
 
 **Arduino IDE 1.X/2.X**
 
-* Download the libary by clicking `here <https://github.com/Every-Flavor-Robotics/motorgo-arduino/raw/main/motorgo-mini-driver.zip>`
+* Download the libary by clicking `here <https://github.com/Every-Flavor-Robotics/motorgo-arduino/raw/main/motorgo-mini-driver.zip>`_
 * Go to `Sketch > Include Library > Add .ZIP Library...`
 * Select the downloaded file
 
 **PlatformIO**
 You can reference the github repo directly in your `platformio.ini` file.
 
-```ini
-lib_deps =
-    https://github.com/Every-Flavor-Robotics/motorgo-mini-driver.git#v1.0.0
-```
+.. code-block:: ini
 
-You can modify v1.0.0 to whichever release tag you prefer, or switch to dev for the latest experimental changes. Example code is available in the examples directory of the library. You can open examples directly in Arduino by going to `File > Examples > MotorGo Mini Driver` (under `Examples from Custom Libaries`). We recommend continuing to :ref:`calibrate-motors` to step through the process of calibrating the motors and encoders before running other examples.
+  lib_deps =
+    https://github.com/Every-Flavor-Robotics/motorgo-mini-driver.git#v1.0.0
+..
+
+You should modify v1.0.0 to whichever release tag you prefer, or switch to dev for the latest experimental changes.
+
+Example code is available in the examples directory of the library. You can open examples directly in Arduino by going to `File > Examples > MotorGo Mini Driver` (under `Examples from Custom Libaries`). We recommend continuing to :ref:`calibrate-motors` to step through the process of calibrating the motors and encoders before running other examples.

--- a/docs/getting_started/software_setup.rst
+++ b/docs/getting_started/software_setup.rst
@@ -4,13 +4,18 @@ Get started writing code for the MotorGo
 
 The MotorGo is programmable in the Arduino IDE or in PlatformIO. At it's core, the MotorGo is an ESP32-S3 microcontroller with built-in motor drivers, so it can be programmed just like any other ESP32. To make it easy to use the onboard features, we have published custom board definitions for the MotorGo and a MotorGo Mini driver library. The MotorGo Mini board defintions define the onboard led pins, I2C, and SPI pins so that you can use them in your code without having to look up the pin numbers. The MotorGo Mini driver library provides a simple interface for controlling the motors and reading the encoders. You only need to use the driver if you want to use the motors or encoders. If you want to use the onboard peripherals, you can use the MotorGo Mini board definitions without the driver library.
 
+There are 3 tools you need to get started writing code for the MotorGo:
 
-Let's walk through the steps to get started writing code for the MotorGo.
+* MotorGo Mini Board Definitions: Let's you program the MotorGo Mini in Arduino/PlatformIO
+* MotorGo Mini Driver: Provides functions for controlling the motors with the onboard motor controllers
+* MotorGo Mini GUI: Let's you tune your PID controllers over WiFi (optional)
+
+Let's walk through the steps of setting each of these up.
 
 Setting up board definitions
 ----------------------------
 
-The board definitions are available `here <https://github.com/Every-Flavor-Robotics/motorgo-board-definitions>`_. These will soon be available through the Arduino and PlatformIO board managers. For now, you can download the board definitions and install them manually.
+Follow the steps below to set up the board definitions.
 
 First, install the ESP32 board definitions, if you have not already done so.
 
@@ -27,7 +32,7 @@ First, install the ESP32 board definitions, if you have not already done so.
 * Search for `Espressif 32`
 * Click `Install`
 
-Next, you'll have to install the MotorGo board definition, which is available in the `MotorGo Board Definitions repository <https://github.com/Every-Flavor-Robotics/motorgo-board-definitions>`_.
+Next, follow the steps below to setup the MotorGo board definitions.
 
 **Arduino IDE 1.X/2.X**
 
@@ -36,15 +41,11 @@ Next, you'll have to install the MotorGo board definition, which is available in
 * Go to `Tools > Board > Boards Manager...`
 * Search for `MotorGo`
 * Click `Install`
-* Select
+* Select MotorGo > MotorGo Mini 1 (ESP32-S3) from the list of boards (Tools > Boards) to use the board.
 
 **PlatformIO**
 
-* Clone this respotory
-* Navigate to the root of the this repository
-* Run the python script `python3 setup_platformio.py`
-
-Or you can paste the following commands into your terminal.
+Run the following commands to set up the MotorGo board definitions in PlatformIO.
 
 .. code-block:: bash
 
@@ -60,13 +61,12 @@ To use the board definition, either select the MotorGo Mini 1 from the list of b
 
 
 
-
-If you're in Arduino IDE, you should be able to now select the MotorGo Mini 1 from the board list. If you're in PlatformIO, you should be able to select the MotorGo Mini 1 from the board list OR modify the `board` in `platformio.ini` to `motorgo_mini_1`. To test this is working as expected, you can upload the `Blink` example to the MotorGo Mini 1 board. If the onboard LED blinks, you're good to go!
+To test this is working as expected, you can upload the `Blink` example to the MotorGo Mini 1 board. If the onboard LED blinks, you're good to go!
 
 Setting up the MotorGo Mini driver library
 ------------------------------------------
 
-The MotorGo Mini library provides an easy interface to control motors and read encoders using the onboard hardware. The main code for the library (PlatformIO package) is available `here <https://github.com/Every-Flavor-Robotics/motorgo-mini-driver>`_. The Arduino compatible library is available `here <https://github.com/Every-Flavor-Robotics/motorgo-arduino>`_. Below are instructions for setting the library up.
+The MotorGo Mini library provides an easy interface to control motors and read encoders using the onboard hardware. Below are instructions for setting the library up.
 
 **Arduino IDE 1.X/2.X**
 
@@ -83,6 +83,13 @@ You can reference the github repo directly in your `platformio.ini` file.
     https://github.com/Every-Flavor-Robotics/motorgo-mini-driver.git#v1.0.0
 ..
 
-You should modify v1.0.0 to whichever release tag you prefer, or switch to dev for the latest experimental changes.
+You should modify v1.0.0 to whichever release tag you prefer, or switch to #dev for the latest experimental changes. You can find the latest releases on the `Github repo for the driver <https://github.com/Every-Flavor-Robotics/motorgo-mini-driver/releases>`_
 
 Example code is available in the examples directory of the library. You can open examples directly in Arduino by going to `File > Examples > MotorGo Mini Driver` (under `Examples from Custom Libaries`). We recommend continuing to :ref:`calibrate-motors` to step through the process of calibrating the motors and encoders before running other examples.
+
+Setting up the MotorGo Mini GUI
+-------------------------------
+
+The MotorGo Mini GUI provides an interface on your computer to wirelessly tune PID controllers on the MotorGo Mini. You can find the latest version of the GUI `here <https://github.com/Every-Flavor-Robotics/motorgo-mini-gui/releases>`_. Download and install the correct version for your operating system (.dmg for Mac, .exe for Windows, and .AppImage or .deb for Linux). 
+
+Check out the `balance_bot` or `tune_controllers` examples for a demonstration of setting up the MotorGo to communicate with the GUI.


### PR DESCRIPTION
* Streamline getting started docs for software
* Rename docs from MotorGo Mini Driver to MotorGo Docs
* Add MotorGo Mini GUI setup docs
* General typo fixes.

Closes #87 