### PR TITLE
Fix multiple Arduino package release bugs

### DIFF
--- a/.github/scripts/package_arduino_lib.py
+++ b/.github/scripts/package_arduino_lib.py
@@ -40,7 +40,7 @@ def check_platform(lib_dir: str, safe: bool = True) -> bool:
 
     return False
 
-def print_dependency_summary(dependencies):
+def print_dependency_summary(dependencies, ignore_packages = []):
     """Prints a formatted summary of dependencies and actions taken.
 
     Args:
@@ -60,6 +60,14 @@ def print_dependency_summary(dependencies):
             print(f'\033[93mSkipping: {name}  (Likely a system dependency)\033[0m')  # Yellow =  Skipping
         else:
             print(f'\033[91mWarning: Invalid dependency format: {dep}\033[0m')  # Red = Warning
+
+    # Print ignored packages
+    if ignore_packages:
+        print("\n--- Ignored Packages ---")
+        for pkg in ignore_packages:
+            print(f'\033[93m{pkg}\033[0m')
+
+
 
     print("--------------------------\n")
 
@@ -171,7 +179,7 @@ def copy_source_files(pio_lib_path, package_output_dir):
     copy_directory(include_dir, output_src_dir)
     copy_directory(src_dir, output_src_dir)
 
-def install_pio_dependencies(storage_dir: str, dependencies: List[dict]) -> None:
+def install_pio_dependencies(storage_dir: str, dependencies: List[dict], ignore_packages: List[str]) -> None:
     """Installs dependencies using PlatformIO package manager.
 
     Args:
@@ -196,7 +204,7 @@ def install_pio_dependencies(storage_dir: str, dependencies: List[dict]) -> None
 
     print(f"Installing dependencies with command: {pio_install_command}")
 
-    print_dependency_summary(dependencies)
+    print_dependency_summary(dependencies, ignore_packages)
 
     # Run PlatformIO package installation
     result = subprocess.run(pio_install_command, capture_output=True)
@@ -226,7 +234,7 @@ def package_arduino_lib(path_to_library_json, storage_dir, output_dir, ignore_pa
     with open(path_to_library_json, 'r') as f:
         data = json.load(f)
 
-    install_pio_dependencies(storage_dir, data.get("dependencies", []))
+    install_pio_dependencies(storage_dir, data.get("dependencies", []), ignore_packages)
 
     # Packaging Logic
     package_output_dir = os.path.join(output_dir, repo_name)

--- a/.github/scripts/package_arduino_lib.py
+++ b/.github/scripts/package_arduino_lib.py
@@ -238,7 +238,11 @@ def package_arduino_lib(path_to_library_json, storage_dir, output_dir, ignore_pa
 
     # Packaging Logic
     package_output_dir = os.path.join(output_dir, repo_name)
-    os.makedirs(package_output_dir, exist_ok=True)  # Ensure the main output directory exists
+    if os.path.exists(package_output_dir):
+        shutil.rmtree(package_output_dir)  # Recursively delete the contents of package_output_dir
+
+    # Create the main output directory
+    os.makedirs(package_output_dir)
 
     # Iterate over installed dependency directories and package
     for lib_dir in os.listdir(storage_dir):

--- a/.github/scripts/package_arduino_lib.py
+++ b/.github/scripts/package_arduino_lib.py
@@ -213,9 +213,10 @@ def install_pio_dependencies(storage_dir: str, dependencies: List[dict]) -> None
 @click.command()
 @click.argument('path_to_library_json', type=click.Path(exists=True))
 @click.option('--storage-dir', default="./temp_deps", help="The directory to install the dependencies to.")
-@click.option('--output-dir', default="./output", help="Output directory for packaging the driver.")  # New Click option
+@click.option('--output-dir', default="./output", help="Output directory for packaging the driver.")
+@click.option('--ignore-packages', multiple=True, help="Names of packages to ignore when packaging.")
 @click.argument('repo_name')  # The argument to receive the repository name
-def package_arduino_lib(path_to_library_json, storage_dir, output_dir, repo_name):
+def package_arduino_lib(path_to_library_json, storage_dir, output_dir, ignore_packages, repo_name):
     """Installs dependencies specified in a PlatformIO library.json file.
 
     Args:
@@ -234,6 +235,15 @@ def package_arduino_lib(path_to_library_json, storage_dir, output_dir, repo_name
     # Iterate over installed dependency directories and package
     for lib_dir in os.listdir(storage_dir):
         lib_path = os.path.join(storage_dir, lib_dir)
+        # Extract the package name
+        lib_name = os.path.basename(lib_dir)
+
+        # Check if the package should be ignored
+        if lib_name in ignore_packages:
+            # Print in Yellow
+            print(f"\033[93mSkipping: {lib_dir}  (Ignored)\033[0m")
+            continue
+
         # Confirm that the library is an ESP32 PlatformIO library
         if os.path.isdir(lib_path) and check_platform(lib_path, safe = False):
             copy_source_files(lib_path, package_output_dir)

--- a/.github/scripts/package_arduino_lib.py
+++ b/.github/scripts/package_arduino_lib.py
@@ -293,7 +293,7 @@ def package_arduino_lib(path_to_library_json, storage_dir, output_dir, ignore_pa
     shutil.copy2(os.path.join(current_repo_path, "library.properties"), package_output_dir)
 
     # Create a zip file of the package_output_dir, put it in the output_dir
-    shutil.make_archive(package_output_dir, 'zip', package_output_dir)
+    shutil.make_archive(package_output_dir, 'zip', os.path.dirname(package_output_dir), os.path.basename(package_output_dir))
 
     print(f'\033[92mPackage zipped to: {package_output_dir}.zip\033[0m')
 

--- a/.github/workflows/package_arduino_lib.yml
+++ b/.github/workflows/package_arduino_lib.yml
@@ -39,16 +39,16 @@ jobs:
             --ignore-packages WiFi
 
       # Open Pull Request
-      # - name: Create Pull Request
-      #   uses: peter-evans/create-pull-request@v6
-      #   with:
-      #     token: ${{ secrets.MOTORGO_ARDUINO_KEY }}
-      #     # /$GITHUB_WORKSPACE/motorgo-arduino
-      #     path: /${{ github.workspace }}/motorgo-arduino
-      #     commit-message: Automated Arduino Package Update
-      #     branch: auto-package-update/${{ github.sha }}
-      #     title: Arduino Library Update to ${{ github.sha }}
-      #     body: |
-      #       Automated update of the Arduino library package
-      #       Please review changes.
-      #     base: main # The branch to open the PR against
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.MOTORGO_ARDUINO_KEY }}
+          # /$GITHUB_WORKSPACE/motorgo-arduino
+          path: /${{ github.workspace }}/motorgo-arduino
+          commit-message: Automated Arduino Package Update
+          branch: auto-package-update/${{ github.sha }}
+          title: Arduino Library Update to ${{ github.sha }}
+          body: |
+            Automated update of the Arduino library package
+            Please review changes.
+          base: main # The branch to open the PR against

--- a/.github/workflows/package_arduino_lib.yml
+++ b/.github/workflows/package_arduino_lib.yml
@@ -39,16 +39,16 @@ jobs:
             --ignore-packages WiFi
 
       # Open Pull Request
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.MOTORGO_ARDUINO_KEY }}
-          # /$GITHUB_WORKSPACE/motorgo-arduino
-          path: /${{ github.workspace }}/motorgo-arduino
-          commit-message: Automated Arduino Package Update
-          branch: auto-package-update/${{ github.sha }}
-          title: Arduino Library Update to ${{ github.sha }}
-          body: |
-            Automated update of the Arduino library package
-            Please review changes.
-          base: main # The branch to open the PR against
+      # - name: Create Pull Request
+      #   uses: peter-evans/create-pull-request@v6
+      #   with:
+      #     token: ${{ secrets.MOTORGO_ARDUINO_KEY }}
+      #     # /$GITHUB_WORKSPACE/motorgo-arduino
+      #     path: /${{ github.workspace }}/motorgo-arduino
+      #     commit-message: Automated Arduino Package Update
+      #     branch: auto-package-update/${{ github.sha }}
+      #     title: Arduino Library Update to ${{ github.sha }}
+      #     body: |
+      #       Automated update of the Arduino library package
+      #       Please review changes.
+      #     base: main # The branch to open the PR against

--- a/.github/workflows/package_arduino_lib.yml
+++ b/.github/workflows/package_arduino_lib.yml
@@ -36,7 +36,7 @@ jobs:
           python .github/scripts/package_arduino_lib.py library.json motorgo-mini-driver \
             --output-dir $GITHUB_WORKSPACE/motorgo-arduino/ \
             --storage-dir ./tmp \
-            --ignore-packages Wifi
+            --ignore-packages WiFi
 
       # Open Pull Request
       - name: Create Pull Request

--- a/.github/workflows/package_arduino_lib.yml
+++ b/.github/workflows/package_arduino_lib.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           REPO_NAME: ${{ github.repository }} # Set environment variable
         run: |
-          python .github/scripts/package_arduino_lib.py library.json motorgo-mini-driver \
+          python .github/scripts/package_arduino_lib.py library.json MotorGo_Mini_Driver \
             --output-dir $GITHUB_WORKSPACE/motorgo-arduino/ \
             --storage-dir ./tmp \
             --ignore-packages WiFi

--- a/.github/workflows/package_arduino_lib.yml
+++ b/.github/workflows/package_arduino_lib.yml
@@ -3,8 +3,6 @@ name: Package Arduino Library and Submit PR
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [bug-94/fix-arduino-build]
 
 jobs:
   build_package:

--- a/.github/workflows/package_arduino_lib.yml
+++ b/.github/workflows/package_arduino_lib.yml
@@ -3,6 +3,8 @@ name: Package Arduino Library and Submit PR
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [bug-94/fix-arduino-build]
 
 jobs:
   build_package:
@@ -33,7 +35,8 @@ jobs:
         run: |
           python .github/scripts/package_arduino_lib.py library.json motorgo-mini-driver \
             --output-dir $GITHUB_WORKSPACE/motorgo-arduino/ \
-            --storage-dir ./tmp
+            --storage-dir ./tmp \
+            --ignore-packages Wifi
 
       # Open Pull Request
       - name: Create Pull Request

--- a/examples/balance_bot/src/balance_bot.cpp
+++ b/examples/balance_bot/src/balance_bot.cpp
@@ -1,10 +1,10 @@
 #include <Arduino.h>
+#include <motorgo_mini.h>
 
 #include "Wire.h"
 #include "common/lowpass_filter.h"
 #include "common/pid.h"
 #include "configurable.h"
-#include "motorgo_mini.h"
 #include "pid_manager.h"
 #include "sensorgo_mpu6050.h"
 

--- a/examples/calibrate_motors/src/calibrate_motors.cpp
+++ b/examples/calibrate_motors/src/calibrate_motors.cpp
@@ -1,6 +1,5 @@
 #include <Arduino.h>
-
-#include "motorgo_mini.h"
+#include <motorgo_mini.h>
 
 MotorGo::MotorGoMini motorgo_mini;
 MotorGo::MotorChannel& motor_ch0 = motorgo_mini.ch0;

--- a/examples/read_encoders/src/read_encoders.cpp
+++ b/examples/read_encoders/src/read_encoders.cpp
@@ -1,6 +1,5 @@
 #include <Arduino.h>
-
-#include "motorgo_mini.h"
+#include <motorgo_mini.h>
 
 MotorGo::MotorGoMini motorgo_mini;
 MotorGo::MotorChannel& motor_ch0 = motorgo_mini.ch0;

--- a/examples/spin_two_motors/src/spin_two_motors.cpp
+++ b/examples/spin_two_motors/src/spin_two_motors.cpp
@@ -1,6 +1,5 @@
 #include <Arduino.h>
-
-#include "motorgo_mini.h"
+#include <motorgo_mini.h>
 
 MotorGo::MotorGoMini motorgo_mini;
 MotorGo::MotorChannel& motor_left = motorgo_mini.ch0;

--- a/examples/tune_controllers/src/tune_controllers.cpp
+++ b/examples/tune_controllers/src/tune_controllers.cpp
@@ -1,8 +1,8 @@
 #include <Arduino.h>
 #include <ESPmDNS.h>
+#include <motorgo_mini.h>
 
 #include "configurable.h"
-#include "motorgo_mini.h"
 #include "pid_manager.h"
 #include "web_server.h"
 

--- a/examples/two_way_haptic_knob/src/two_way_haptic_knob.cpp
+++ b/examples/two_way_haptic_knob/src/two_way_haptic_knob.cpp
@@ -1,7 +1,7 @@
 #include <Arduino.h>
+#include <motorgo_mini.h>
 
 #include "configurable.h"
-#include "motorgo_mini.h"
 #include "pid_manager.h"
 
 // UPDATE THESE VALUES


### PR DESCRIPTION
* Add ignore-packages argument to explicitly skip packages from being packaged in Arduino lib
* Add WiFi to ignore-packages argument
* Rename Arduino package base name to MotorGo_Mini_Driver
* Include base directory when zipping Arduino library
* Move motorgo_mini.h include to top of example scripts to enable Arduino to correctly import

Closes #94 