### PR TITLE
Fix broken doc versioning

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -5,10 +5,7 @@ on:
     branches:
       - dev
       - main
-    # types: [closed]
-  push:
-    branches:
-      - bug-94/fix-multiversion
+    types: [closed]
 
 jobs:
   build-and-deploy-docs:

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Build Documentation
         run: |
           cd docs
+          git branch -a
           sphinx-multiversion . _build/html -D 'exhale_args.containmentFolder=${sourcedir}/api'
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - dev
       - main
-    types: [closed]
+      - bug-94/fix-multiversion
+    # types: [closed]
 
 jobs:
   build-and-deploy-docs:
@@ -29,7 +30,9 @@ jobs:
       - name: Build Documentation
         run: |
           cd docs
-          sphinx-build -b html . _build/html/${{ github.ref_name }}  # Version matches branch
+          sphinx-multiversion -b html . _build/html
+
+        # sphinx-build -b html . _build/html/${{ github.ref_name }}  # Version matches branch
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build Documentation
         run: |
           cd docs
-          sphinx-multiversion -b html . _build/html
+          sphinx-multiversion . _build/html
 
         # sphinx-build -b html . _build/html/${{ github.ref_name }}  # Version matches branch
 

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -32,9 +32,7 @@ jobs:
       - name: Build Documentation
         run: |
           cd docs
-          sphinx-multiversion . _build/html
-
-        # sphinx-build -b html . _build/html/${{ github.ref_name }}  # Version matches branch
+          sphinx-multiversion . _build/html -D 'exhale_args.containmentFolder=${sourcedir}/api'
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -5,8 +5,10 @@ on:
     branches:
       - dev
       - main
-      - bug-94/fix-multiversion
     # types: [closed]
+  push:
+    branches:
+      - bug-94/fix-multiversion
 
 jobs:
   build-and-deploy-docs:

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Build Documentation
         run: |
           cd docs
-          git branch -a
+          git checkout --track origin/dev
+          git checkout --track origin/main
+          git checkout ${{ github.ref }}
           sphinx-multiversion . _build/html -D 'exhale_args.containmentFolder=${sourcedir}/api'
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -16,7 +16,9 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,0 +1,19 @@
+{% extends "!page.html" %}
+{% block body %}
+{% if current_version and latest_version and current_version != latest_version %}
+<p>
+    <strong>
+        {% if current_version.is_released %}
+        You're reading an old version of this documentation.
+        If you want up-to-date information, please have a look at <a
+            href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
+        {% else %}
+        You're reading the documentation for a development version.
+        For the latest released version, please have a look at <a
+            href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
+        {% endif %}
+    </strong>
+</p>
+{% endif %}
+{{ super() }}
+{% endblock %}%

--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -1,0 +1,27 @@
+{%- if current_version %}
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+    <span class="rst-current-version" data-toggle="rst-current-version">
+        <span class="fa fa-book"> Other Versions</span>
+        v: {{ current_version.name }}
+        <span class="fa fa-caret-down"></span>
+    </span>
+    <div class="rst-other-versions">
+        {%- if versions.tags %}
+        <dl>
+            <dt>Tags</dt>
+            {%- for item in versions.tags %}
+            <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
+            {%- endfor %}
+        </dl>
+        {%- endif %}
+        {%- if versions.branches %}
+        <dl>
+            <dt>Branches</dt>
+            {%- for item in versions.branches %}
+            <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
+            {%- endfor %}
+        </dl>
+        {%- endif %}
+    </div>
+</div>
+{%- endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ html_sidebars = {'**': ['logo-text.html', 'globaltoc.html', 'searchbox.html']}
 # -- Options for Multiversion  ------------------------------------------------
 
 # Whitelist the versions you want included (adjust as needed)
-smv_branch_whitelist = r'^main|dev|api-docs$'
+smv_branch_whitelist = r'^main|dev|bug-94/fix-multiversion$'
 smv_tag_whitelist = r'^.*$'
 
 # Output subdirectory based on branch for simple version separation

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ html_sidebars = {'**': ['logo-text.html', 'globaltoc.html', 'searchbox.html']}
 # -- Options for Multiversion  ------------------------------------------------
 
 # Whitelist the versions you want included (adjust as needed)
-smv_branch_whitelist = r'^main|dev|bug-94/fix-multiversion$'
+smv_branch_whitelist = r'^main|dev$'
 smv_tag_whitelist = r'^.*$'
 
 # Output subdirectory based on branch for simple version separation


### PR DESCRIPTION
* Corrects usage of `sphinx-multiversion` to build all versions of the documentation
* Adds option on documentation page to switch between doc versions
* Adds banner to warn users about old doc versions

Closes #94 