### PR TITLE
Patch docs workflow to continue if tracking main or dev fail

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -29,11 +29,17 @@ jobs:
           sudo apt-get install doxygen
           pip install sphinx breathe exhale sphinx_rtd_theme sphinxcontrib-versioning sphinx-multiversion
 
+      - name: Checkout dev branch
+        continue-on-error: true
+        run: git checkout --track origin/dev
+
+      - name: Checkout main branch
+        continue-on-error: true
+        run: git checkout --track origin/main
+
       - name: Build Documentation
         run: |
           cd docs
-          git checkout --track origin/dev
-          git checkout --track origin/main
           git checkout ${{ github.ref }}
           sphinx-multiversion . _build/html -D 'exhale_args.containmentFolder=${sourcedir}/api'
 


### PR DESCRIPTION
When a new PR is submitted to the dev branch, the build currently fail as it tries to setup a local tracking branch for dev. This PR updates the workflow to create separate steps for setting up tracking branches, and allows the workflow to continue if even if those fail.