### PR TITLE
Trigger docs build on release publish

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -6,6 +6,8 @@ on:
       - dev
       - main
     types: [closed]
+  release:
+    types: [published]
 
 jobs:
   build-and-deploy-docs:


### PR DESCRIPTION
Closes #100 

Adds a trigger for publish_docs workflow for published release