### PR TITLE
Update Arduino library generation to match Arduino Library index standards

### DIFF
--- a/.github/scripts/package_arduino_lib.py
+++ b/.github/scripts/package_arduino_lib.py
@@ -240,11 +240,13 @@ def package_arduino_lib(path_to_library_json, storage_dir, output_dir, ignore_pa
     # Do not create a subdirectory for the package, just use the output_dir
     # package_output_dir = os.path.join(output_dir, repo_name)
     package_output_dir = output_dir
+    # Directories to exclude when deleting the contents of package_output_dir
+    exclude_dirs = [".git", ".github"]
     if os.path.exists(package_output_dir):
         # Recursively delete the contents of package_output_dir
         # Do not delete .git directory
         for item in os.listdir(package_output_dir):
-            if item != ".git":
+            if item not in exclude_dirs:
                 item_path = os.path.join(package_output_dir, item)
                 if os.path.isdir(item_path):
                     shutil.rmtree(item_path)

--- a/.github/scripts/package_arduino_lib.py
+++ b/.github/scripts/package_arduino_lib.py
@@ -237,7 +237,9 @@ def package_arduino_lib(path_to_library_json, storage_dir, output_dir, ignore_pa
     install_pio_dependencies(storage_dir, data.get("dependencies", []), ignore_packages)
 
     # Packaging Logic
-    package_output_dir = os.path.join(output_dir, repo_name)
+    # Do not create a subdirectory for the package, just use the output_dir
+    # package_output_dir = os.path.join(output_dir, repo_name)
+    package_output_dir = output_dir
     if os.path.exists(package_output_dir):
         shutil.rmtree(package_output_dir)  # Recursively delete the contents of package_output_dir
 
@@ -296,10 +298,7 @@ def package_arduino_lib(path_to_library_json, storage_dir, output_dir, ignore_pa
     shutil.copy2(path_to_library_json, package_output_dir)
     shutil.copy2(os.path.join(current_repo_path, "library.properties"), package_output_dir)
 
-    # Create a zip file of the package_output_dir, put it in the output_dir
-    shutil.make_archive(package_output_dir, 'zip', os.path.dirname(package_output_dir), os.path.basename(package_output_dir))
-
-    print(f'\033[92mPackage zipped to: {package_output_dir}.zip\033[0m')
+    # print(f'\033[92mPackage zipped to: {package_output_dir}.zip\033[0m')
 
 
 

--- a/.github/scripts/package_arduino_lib.py
+++ b/.github/scripts/package_arduino_lib.py
@@ -241,7 +241,15 @@ def package_arduino_lib(path_to_library_json, storage_dir, output_dir, ignore_pa
     # package_output_dir = os.path.join(output_dir, repo_name)
     package_output_dir = output_dir
     if os.path.exists(package_output_dir):
-        shutil.rmtree(package_output_dir)  # Recursively delete the contents of package_output_dir
+        # Recursively delete the contents of package_output_dir
+        # Do not delete .git directory
+        for item in os.listdir(package_output_dir):
+            if item != ".git":
+                item_path = os.path.join(package_output_dir, item)
+                if os.path.isdir(item_path):
+                    shutil.rmtree(item_path)
+                else:
+                    os.remove(item_path)
 
     # Create the main output directory
     os.makedirs(package_output_dir)

--- a/.github/scripts/package_arduino_lib.py
+++ b/.github/scripts/package_arduino_lib.py
@@ -250,9 +250,9 @@ def package_arduino_lib(path_to_library_json, storage_dir, output_dir, ignore_pa
                     shutil.rmtree(item_path)
                 else:
                     os.remove(item_path)
-
-    # Create the main output directory
-    os.makedirs(package_output_dir)
+    else:
+        # Create the main output directory
+        os.makedirs(package_output_dir)
 
     # Iterate over installed dependency directories and package
     for lib_dir in os.listdir(storage_dir):

--- a/.github/scripts/package_arduino_lib.py
+++ b/.github/scripts/package_arduino_lib.py
@@ -218,6 +218,26 @@ def install_pio_dependencies(storage_dir: str, dependencies: List[dict], ignore_
         # Print in Green
         print(f"\033[92mDependencies installed successfully!\033[0m")
 
+
+def copy_additional_files(files: list, output_dir: str):
+    """Copies additional files to the output directory.
+
+    Args:
+        files (list): List of files to copy.
+        output_dir (str): The output directory where files will be placed.
+
+    """
+
+    for file_path in files:
+        if os.path.exists(file_path):
+            if os.path.isdir(file_path):
+                copy_directory(file_path, output_dir)
+            else:
+                shutil.copy2(file_path, output_dir)
+        else:
+            print(f"\033[93mWarning: File or directory '{file_path}' does not exist.\033[0m"
+                    f"\n\033[93mSkipping...\033[0m")
+
 @click.command()
 @click.argument('path_to_library_json', type=click.Path(exists=True))
 @click.option('--storage-dir', default="./temp_deps", help="The directory to install the dependencies to.")
@@ -305,10 +325,11 @@ def package_arduino_lib(path_to_library_json, storage_dir, output_dir, ignore_pa
             if os.path.exists(examples_dir) else f'\033[93mNo examples found in: {examples_dir}\033[0m')
 
     # Copy library.json and library.properties to root of the output_dir
-    shutil.copy2(path_to_library_json, package_output_dir)
-    shutil.copy2(os.path.join(current_repo_path, "library.properties"), package_output_dir)
+    copy_additional_files([path_to_library_json,
+                            os.path.join(current_repo_path, "library.properties"),
+                            os.path.join(current_repo_path, "README.rst"),
+                            os.path.join(current_repo_path, "LICENSE")], package_output_dir)
 
-    # print(f'\033[92mPackage zipped to: {package_output_dir}.zip\033[0m')
 
 
 

--- a/.github/workflows/package_arduino_lib.yml
+++ b/.github/workflows/package_arduino_lib.yml
@@ -41,8 +41,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.MOTORGO_ARDUINO_KEY }}
-          # /$GITHUB_WORKSPACE/motorgo-arduino
-          path: /${{ github.workspace }}/motorgo-arduino
+          path: motorgo-arduino
           commit-message: Automated Arduino Package Update
           branch: auto-package-update/${{ github.sha }}
           title: Arduino Library Update to ${{ github.sha }}

--- a/.github/workflows/package_arduino_lib.yml
+++ b/.github/workflows/package_arduino_lib.yml
@@ -2,7 +2,7 @@ name: Package Arduino Library and Submit PR
 
 on:
   pull_request:
-    branches: [main, feature-109/arduino-library-index-fixes]
+    branches: [main, dev]
 
 jobs:
   build_package:

--- a/.github/workflows/package_arduino_lib.yml
+++ b/.github/workflows/package_arduino_lib.yml
@@ -2,7 +2,7 @@ name: Package Arduino Library and Submit PR
 
 on:
   pull_request:
-    branches: [main, dev]
+    branches: [main]
 
 jobs:
   build_package:

--- a/.github/workflows/package_arduino_lib.yml
+++ b/.github/workflows/package_arduino_lib.yml
@@ -2,7 +2,7 @@ name: Package Arduino Library and Submit PR
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, feature-109/arduino-library-index-fixes]
 
 jobs:
   build_package:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Every Flavor, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/library.properties
+++ b/library.properties
@@ -1,12 +1,12 @@
-name=MotorGo Mini Driver
+name=MotorGo-Mini-Driver
 version=0.0.1
 author=MotorGo, LLC
-maintainer=support@motorgo.com
+maintainer=support@motorgo.net
 sentence=The MotorGo Mini driver provides an API to interface with the motor controllers on the MotorGo Mini board.
-paragraph=The MotorGo Mini driver provides an API to interface with the motor controllers on the MotorGo Mini board.
+paragraph=The driver supports configuring the motor controllers, reading encoder data, and setting up PID controllers. It additionally provides an easy interface to communicate with the MotorGo Mini GUI for tuning your controllers.
 category=Device Control
-url=https://www.motorgo.com
+url=https://www.motorgo.net
 architectures=esp32
 repository=https://github.com/Roam-Studios/motorgo-mini-driver
 license=MIT
-depends=Simple FOC,SimpleFOCDrivers,ESP-Options
+depends=Simple FOC,SimpleFOCDrivers


### PR DESCRIPTION
Closes #109 

* No longer generates a zip file for the package
* Places build files in the root of the MotorGo Arduino repo

Note: Build script needs to be tested before merge