### PR TITLE
Speed up driver compilation

### DIFF
--- a/library.json
+++ b/library.json
@@ -20,7 +20,7 @@
     "dependencies": [
         {
             "name": "Simple FOC",
-            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC.git#6fafa35b73e9c5ba6f5d9259640a5ed328dc2750"
+            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC.git#8e96ba2fd3eb90c7646cded42572a96adeff7e06"
         },
         {
             "name": "SimpleFOCDrivers",

--- a/library.json
+++ b/library.json
@@ -20,11 +20,11 @@
     "dependencies": [
         {
             "name": "Simple FOC",
-            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC.git#8e96ba2fd3eb90c7646cded42572a96adeff7e06"
+            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC.git#9a1b87a2c11d624fd3c3b54146ac517620d4c35c"
         },
         {
             "name": "SimpleFOCDrivers",
-            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC-drivers.git"
+            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC-drivers.git#3c4585c95f640be3cf704b230be615a96a01e326"
         },
         {
             "name": "ESP-Options",

--- a/library.json
+++ b/library.json
@@ -20,7 +20,7 @@
     "dependencies": [
         {
             "name": "Simple FOC",
-            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC.git#9a1b87a2c11d624fd3c3b54146ac517620d4c35c"
+            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC.git#cbbd999c7bec8967ac229b126f2e48d96b93478e"
         },
         {
             "name": "SimpleFOCDrivers",

--- a/library.json
+++ b/library.json
@@ -19,9 +19,8 @@
     "platforms": "esp32-s3-motorgo-mini",
     "dependencies": [
         {
-            "owner": "askuric",
             "name": "Simple FOC",
-            "version": "^2.3.2"
+            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC.git#6fafa35b73e9c5ba6f5d9259640a5ed328dc2750"
         },
         {
             "name": "SimpleFOCDrivers",


### PR DESCRIPTION
Closes #72 

This PR speeds up the driver compile time by removing unnecessary source files from SimpleFOC for other microcontrollers, motor drivers, motor types, and sensors. 

Full change list:
* Switch to our own fork of SimpleFOC
* Pin SimpleFOC version in driver to a specific commit with unnecessary source files removed. 