### PR TITLE
Changed dashes to underscores in Arduino library name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=MotorGo-Mini-Driver
+name=MotorGo_Mini_Driver
 version=0.0.1
 author=MotorGo, LLC
 maintainer=support@motorgo.net


### PR DESCRIPTION
Closes #120 

Small PR to change the Arduino library name to use underscores instead of dashes.