### PR TITLE
Update Arduino library build to install correct version of SimpleFOC

### DIFF
--- a/.github/scripts/package_arduino_lib.py
+++ b/.github/scripts/package_arduino_lib.py
@@ -31,7 +31,14 @@ def check_platform(lib_dir: str, safe: bool = True) -> bool:
     with open(library_json_path, 'r') as f:
         data = json.load(f)
 
-    platform = data.get("platforms", [])
+    # If platform not present, return based on safe flag
+    platform = data.get("platforms", None)
+    if not platform:
+        if safe:
+            return False
+        else:
+            return True
+
     if isinstance(platform, list):
         if "espressif32" in platform:
             return True
@@ -202,7 +209,8 @@ def install_pio_dependencies(storage_dir: str, dependencies: List[dict], ignore_
             pio_install_command.append("--library")
             pio_install_command.append(dep)
 
-    print(f"Installing dependencies with command: {pio_install_command}")
+    # Convert to string and print
+    print(f"Installing dependencies with command:\n{' '.join(pio_install_command)}")
 
     print_dependency_summary(dependencies, ignore_packages)
 

--- a/library.json
+++ b/library.json
@@ -24,7 +24,7 @@
         },
         {
             "name": "SimpleFOCDrivers",
-            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC-drivers.git#3c4585c95f640be3cf704b230be615a96a01e326"
+            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC-drivers.git#639943f76a16a706b5125af28e5599060a909cea"
         },
         {
             "name": "ESP-Options",


### PR DESCRIPTION
Latest version of SimpleFOC was being installed by the platformio dependency manager because it was specified as a dependency in Arduino-FOC-drivers. Additionally, Arduino-FOC source files were not being correctly copied over due to the recent addition of library.json to SimpleFOC.

Changes: 
* Update pinned version of Arduino-FOC-Drivers to version without SimpleFOC dependency
* Update arduino lib build script to handle correctly check platform version for a library with a library.json, without the platforms explicitly specified.