### PR TITLE
Upgrade to SimpleFOC 2.3.4

### DIFF
--- a/examples/balance_bot/platformio.ini
+++ b/examples/balance_bot/platformio.ini
@@ -10,10 +10,11 @@
 
 
 [env:balance_bot]
-platform = platformio/espressif32
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.07/platform-espressif32.zip
 board = motorgo_mini_1
 framework = arduino
 monitor_speed = 115200
+lib_ldf_mode = deep
 lib_deps =
     https://github.com/Every-Flavor-Robotics/motorgo-mini-driver.git#dev
     https://github.com/Every-Flavor-Robotics/mpu6050-driver.git#0.1

--- a/examples/calibrate_motors/platformio.ini
+++ b/examples/calibrate_motors/platformio.ini
@@ -10,10 +10,11 @@
 
 
 [env:calibrate_motors]
-platform = platformio/espressif32
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.07/platform-espressif32.zip
 board = motorgo_mini_1
 framework = arduino
 monitor_speed = 115200
+lib_ldf_mode = deep
 lib_deps =
     https://github.com/Every-Flavor-Robotics/motorgo-mini-driver.git#dev
 

--- a/examples/read_encoders/platformio.ini
+++ b/examples/read_encoders/platformio.ini
@@ -10,9 +10,10 @@
 
 
 [env:read_encoders]
-platform = platformio/espressif32
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.07/platform-espressif32.zip
 board = motorgo_mini_1
 framework = arduino
 monitor_speed = 115200
+lib_ldf_mode = deep
 lib_deps =
     https://github.com/Every-Flavor-Robotics/motorgo-mini-driver.git#dev

--- a/examples/spin_two_motors/platformio.ini
+++ b/examples/spin_two_motors/platformio.ini
@@ -10,9 +10,10 @@
 
 
 [env:spin_two_motors]
-platform = platformio/espressif32
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.07/platform-espressif32.zip
 board = motorgo_mini_1
 framework = arduino
 monitor_speed = 115200
+lib_ldf_mode = deep
 lib_deps =
     https://github.com/Every-Flavor-Robotics/motorgo-mini-driver.git#dev

--- a/examples/tune_controllers/platformio.ini
+++ b/examples/tune_controllers/platformio.ini
@@ -10,9 +10,10 @@
 
 
 [env:tune_controllers]
-platform = platformio/espressif32
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.07/platform-espressif32.zip
 board = motorgo_mini_1
 framework = arduino
 monitor_speed = 115200
+lib_ldf_mode = deep
 lib_deps =
     https://github.com/Every-Flavor-Robotics/motorgo-mini-driver.git#dev

--- a/examples/two_way_haptic_knob/platformio.ini
+++ b/examples/two_way_haptic_knob/platformio.ini
@@ -10,9 +10,10 @@
 
 
 [env:two_way_haptic_knob]
-platform = platformio/espressif32
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.07/platform-espressif32.zip
 board = motorgo_mini_1
 framework = arduino
 monitor_speed = 115200
+lib_ldf_mode = deep
 lib_deps =
     https://github.com/Every-Flavor-Robotics/motorgo-mini-driver.git#dev

--- a/library.json
+++ b/library.json
@@ -20,11 +20,11 @@
     "dependencies": [
         {
             "name": "Simple FOC",
-            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC.git#cbbd999c7bec8967ac229b126f2e48d96b93478e"
+            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC.git#c72f063f3d2d2e26d49a22a7383310cf8f88134b"
         },
         {
             "name": "SimpleFOCDrivers",
-            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC-drivers.git#639943f76a16a706b5125af28e5599060a909cea"
+            "version": "https://github.com/Every-Flavor-Robotics/Arduino-FOC-drivers.git#1575b9b479e0e4eda9f7fce983b5010bd1f9fce7"
         },
         {
             "name": "ESP-Options",


### PR DESCRIPTION
Closes #125 

Update to support the latest version of SimpleFOC and SimpleFOC drivers. These versions fix current sense issues and also 
migrate to esp32-arduino core 3.x.x. For the PlatformIO projects, we are switching over to the pioarduino fork of the esp framework ([here](https://github.com/pioarduino/platform-espressif32)).

This example project builds will fail because the motorgo boards are not supported in arduino-esp32 at the moment